### PR TITLE
fix path->uri conversion in windows

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -7,11 +7,11 @@
          racket/match
          racket/set
          syntax/modread
+         (only-in net/url path->url url->string)
          "interfaces.rkt"
          "msg-io.rkt")
 
-(define (path->uri path)
-  (string-append "file://" path))
+(define path->uri (compose url->string path->url))
 
 (struct Decl (require? left right) #:transparent)
 


### PR DESCRIPTION
This addresses a bug that I observed on Windows in VS Code using the Magic Racket extension:  diagnostics such as "unused require" do not underline the offending fragment of code, and clicking on the "Problem" item in VS Code shows an error message instead of jumping to the problematic code.

I tracked this down to bogus URIs in diagnostic messages.  A bad URI looks like: `"file://c:/foo/bar/baz.rkt"`.  A correct URI has a one more slash near the beginning: `"file:///c:/foo/bar/baz.rkt"`.

I  `raco pkg install`ed this patched server, and VS Code appears to be happy with the result.

Unfortunately I don't see how to write a platform-independent unit test for this change (e.g., there doesn't seem to be a parameter that allows controlling the current path convention).  However, I did spot check an example on both Windows and Linux, see below.  I don't have VS Code running in a Unix environment (my Linux env is a really just a WSL installation on the Windows machine).  So it'd be useful if a reviewer could actually try this patch on a Mac or Linux VS Code installation just to make sure this isn't broken on Unix.

```
Welcome to Racket v7.8 [cs].
> (system-type 'os)
'windows
> (require net/url)
> (define path->uri (compose url->string path->url))
> (path->uri "c:/foo/bar/baz.rkt")
"file:///c:/foo/bar/baz.rkt"
```

```
Welcome to Racket v7.8 [cs].
> (system-type 'os)
'unix
> (require net/url)
> (define path->uri (compose url->string path->url))
> (path->uri "/foo/bar/baz.rkt")
"file:///foo/bar/baz.rkt"
```
