### PR TITLE
Add formatting support

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -80,7 +80,7 @@
 
 (define ((error-diagnostics src) exn)
   (define msg (exn-message exn))
-  (cond 
+  (cond
     [(exn:srclocs? exn)
      (define srclocs ((exn:srclocs-accessor exn) exn))
      (for/list ([sl (in-list srclocs)])
@@ -92,15 +92,15 @@
                    #:message msg))]
     [(exn:missing-module? exn)
      ;; Hack:
-     ;; We do not have any source location for the offending `require`, but the language 
-     ;; server protocol requires a valid range object.  So we punt and just highlight the 
+     ;; We do not have any source location for the offending `require`, but the language
+     ;; server protocol requires a valid range object.  So we punt and just highlight the
      ;; first character.
-     ;; This is very close to DrRacket's behavior:  it also has no source location to work with, 
+     ;; This is very close to DrRacket's behavior:  it also has no source location to work with,
      ;; however it simply doesn't highlight any code.
-     (define silly-range 
+     (define silly-range
       (Range #:start (Pos #:line 0 #:char 0) #:end (Pos #:line 0 #:char 0)))
      (list (Diagnostic #:range silly-range
-                       #:severity Diag-Error 
+                       #:severity Diag-Error
                        #:source "Racket"
                        #:message msg))]
       [else (error 'error-diagnostics "unexpected failure: ~a" exn)]))
@@ -112,7 +112,8 @@
 ;; XXX For now, use default indentation for everything (until we support
 ;; XXX custom #langs).
 (define (get-indenter doc-text)
-  #f)
+  (define lang-info (read-language (open-input-string (send doc-text get-text))))
+  (lang-info 'drracket:indentation))
 
 (define (check-syntax src doc-text)
   (define indenter (get-indenter doc-text))

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -113,7 +113,7 @@
 ;; XXX custom #langs).
 (define (get-indenter doc-text)
   (define lang-info (read-language (open-input-string (send doc-text get-text))))
-  (lang-info 'drracket:indentation))
+  (lang-info 'drracket:indentation #f))
 
 (define (check-syntax src doc-text)
   (define indenter (get-indenter doc-text))

--- a/methods.rkt
+++ b/methods.rkt
@@ -112,7 +112,6 @@
                'referencesProvider #t
                'documentHighlightProvider #t
                'documentSymbolProvider #t
-               ;; XXX: implement non-range formatting
                'documentFormattingProvider #t
                'documentRangeFormattingProvider #t))
      (define resp (success-response id (hasheq 'capabilities server-capabilities)))

--- a/methods.rkt
+++ b/methods.rkt
@@ -69,6 +69,8 @@
        (text-document/references id params)]
       ["textDocument/documentSymbol"
        (text-document/document-symbol id params)]
+      ["textDocument/formatting"
+       (text-document/formatting! id params)]
       ["textDocument/rangeFormatting"
        (text-document/range-formatting! id params)]
       [_
@@ -111,8 +113,8 @@
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                ;; XXX: implement non-range formatting
-               'documentFormattingProvider #f
-               'documentRangeFormattingProvider #f))
+               'documentFormattingProvider #t
+               'documentRangeFormattingProvider #t))
      (define resp (success-response id (hasheq 'capabilities server-capabilities)))
      (set! already-initialized? #t)
      resp]

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -278,11 +278,14 @@
   (match params
     ;; We're ignoring 'options for now
     [(hash-table ['textDocument (DocIdentifier #:uri uri)])
-     (unless (uri-is-path? uri)
-       (error 'formatting "uri is not a path"))
-     ...
-     (define results ...)
-     (success-response id results)]
+     (match-define (doc doc-text doc-trace)
+       (hash-ref open-docs (string->symbol uri)))
+     (define end-pos (send doc-text last-position))
+     (range-formatting!
+       id
+       (hash-set params
+                 'range (Range #:start (abs-pos->Pos doc-text 0)
+                               #:end (abs-pos->Pos doc-text end-pos))))]
     [_
      (error-response id INVALID-PARAMS "textDocument/formatting failed")]))
 

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -125,7 +125,7 @@
 
 ;; Hover request
 ;; Returns an object conforming to the Hover interface, to
-;; be used as the result of the response message. 
+;; be used as the result of the response message.
 (define (hover id params)
   (match params
     [(hash-table ['textDocument (DocIdentifier #:uri uri)]
@@ -272,6 +272,19 @@
      (success-response id results)]
     [_
      (error-response id INVALID-PARAMS "textDocument/documentSymbol failed")]))
+
+;; Full document formatting request
+(define (formatting! id params)
+  (match params
+    ;; We're ignoring 'options for now
+    [(hash-table ['textDocument (DocIdentifier #:uri uri)])
+     (unless (uri-is-path? uri)
+       (error 'formatting "uri is not a path"))
+     ...
+     (define results ...)
+     (success-response id results)]
+    [_
+     (error-response id INVALID-PARAMS "textDocument/formatting failed")]))
 
 ;; Range Formatting request
 (define (range-formatting! id params)

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -381,4 +381,5 @@
   [document-highlight (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [references (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [document-symbol (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
+  [formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [range-formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]))


### PR DESCRIPTION
This adds formatting support. Gets the indenter using `read-language` and getting the `drracket:indentation` setting (with a default fallback to use the racket indenter).

Making the draft pr now so it's visible. Will be testing in the near future:
 - #lang with different indenter

Closes #1 .