### PR TITLE
Display a link to docs in textDocument/hover

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -6,6 +6,7 @@
          racket/gui/base
          racket/match
          racket/set
+         net/url
          syntax/modread
          (only-in net/url path->url url->string)
          "interfaces.rkt"
@@ -25,6 +26,7 @@
     (init-field src doc-text indenter)
     (define warn-diags (mutable-seteq))
     (define hovers (make-interval-map))
+    (define docs (make-interval-map))
     ;; decl -> (set pos ...)
     (define sym-decls (make-interval-map))
     ;; pos -> decl
@@ -33,6 +35,7 @@
     (define/public (get-indenter) indenter)
     (define/public (get-warn-diags) warn-diags)
     (define/public (get-hovers) hovers)
+    (define/public (get-docs) docs)
     (define/public (get-sym-decls) sym-decls)
     (define/public (get-sym-bindings) sym-bindings)
     ;; Overrides
@@ -46,6 +49,23 @@
       (when (= start finish)
         (set! finish (add1 finish)))
       (interval-map-set! hovers start finish text))
+    ;; Docs
+    (define/override (syncheck:add-docs-menu text start finish id label path def-tag url-tag)
+      (when url
+        (when (= start finish)
+          (set! finish (add1 finish)))
+        (define url (path->url path))
+        (define url2 (if url-tag
+                         (make-url (url-scheme url)
+                                   (url-user url)
+                                   (url-host url)
+                                   (url-port url)
+                                   (url-path-absolute? url)
+                                   (url-path url)
+                                   (url-query url)
+                                   url-tag)
+                         url))
+        (interval-map-set! docs start finish (url->string url2))))
     ;; References
     (define/override (syncheck:add-arrow/name-dup start-src-obj start-left start-right
                                                   end-src-obj end-left end-right

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -139,9 +139,10 @@
      (define pos (line/char->pos doc-text line ch))
      (define-values (start end text)
        (interval-map-ref/bounds hovers pos #f))
+     (define link (interval-map-ref (send doc-trace get-docs) pos #f))
      (define result
        (cond [text
-              (hasheq 'contents text
+              (hasheq 'contents (if link (~a text " - [docs](" (~a "https://docs.racket-lang.org/" (last (string-split link "/doc/"))) ")") text)
                       'range (Range #:start (abs-pos->Pos doc-text start)
                                     #:end   (abs-pos->Pos doc-text end)))]
              [else (hasheq 'contents empty)]))


### PR DESCRIPTION
If docs are found, provide a link after the hover text. A sufficient way of bringing DrRacket's "View documentation for..." functionality to other editors.

![image](https://user-images.githubusercontent.com/5150427/112740735-bd335600-8f3c-11eb-8fd7-68e5a30a5212.png)

The link needs to be converted from filepath to equivalent URL or else editors may open the HTML document in-editor instead of opening it in a new browser - Visual Studio Code exhibits this behavior. So it will fail on library documentation not hosted on docs.racket-lang.org.

