### PR TITLE
Add textDocument/signatureHelp, cache traces

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -67,10 +67,10 @@
                                              (Decl (Decl-require? decl-set) (+ (car d-range) amt) (+ (cdr d-range) amt))
                                              #f)]
                                         [else 
-                                         (set-map decl-set (lambda (d-range) 
+                                         (list->set (set-map decl-set (lambda (d-range) 
                                                              (if (> (car d-range) after)
                                                                  (cons (+ (car d-range) amt) (+ (cdr d-range) amt))
-                                                                 d-range)))]))
+                                                                 d-range))))]))
                        (when result
                          (interval-map-set! int-map (car range) (cdr range) result)))))
     ;; Getters

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -153,9 +153,10 @@
   (for ([lst (in-port (lexer-wrap lexer) in)] #:when (set-member? '(constant string symbol) (first (rest lst))))
     (match-define (list text type paren? start end) lst)
     (interval-map-set! symbols start end (list text type)))
-  ;; Rewind input port
-  (file-position in 0)
   
+  ;; Rewind input port
+  (set! in (open-input-string (send doc-text get-text)))
+  (port-count-lines! in)
   (define err-diags
     (parameterize ([current-annotations trace]
                    [current-namespace ns]

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -147,11 +147,14 @@
     (make-traversal ns src))
   (define in (open-input-string (send doc-text get-text)))
   (port-count-lines! in)
+  ;; Enumerate symbols
   (define lexer (get-lexer in))
   (define symbols (send trace get-symbols))
   (for ([lst (in-port (lexer-wrap lexer) in)] #:when (set-member? '(constant string symbol) (first (rest lst))))
     (match-define (list text type paren? start end) lst)
     (interval-map-set! symbols start end (list text type)))
+  ;; Rewind input port
+  (file-position in 0)
   
   (define err-diags
     (parameterize ([current-annotations trace]

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -176,6 +176,8 @@
   ;; Rewind input port and read syntax
   (set! in (open-input-string text))
   (port-count-lines! in)
+  (define warn-diags (send trace get-warn-diags))
+  (set-clear! warn-diags)
   (define err-diags
     (parameterize ([current-annotations trace]
                    [current-namespace ns]
@@ -187,7 +189,7 @@
         (add-syntax (expand stx))
         (done)
         (list))))
-  (define all-diags (append err-diags (set->list (send trace get-warn-diags))))
+  (define all-diags (append err-diags (set->list warn-diags)))
   (display-message/flush (diagnostics-message (path->uri src) all-diags))
   trace)
 

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -6,7 +6,6 @@
          racket/gui/base
          racket/match
          racket/set
-         racket/format
          racket/list
          syntax-color/module-lexer
          syntax-color/racket-lexer

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -51,7 +51,7 @@
       (move-interior-intervals sym-bindings (- start 1) inc)
       (map (lambda (int-map) (interval-map-expand! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))
     (define/public (contract start end)
-      (define dec (- 0 end start))
+      (define dec (- start end))
       (move-interior-intervals sym-decls end dec)
       (move-interior-intervals sym-bindings end dec)
       (map (lambda (int-map) (interval-map-contract! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -99,12 +99,6 @@
       (set-add! warn-diags diag))
     (super-new)))
 
-(define (diagnostics-message uri diags)
-  (hasheq 'jsonrpc "2.0"
-          'method "textDocument/publishDiagnostics"
-          'params (hasheq 'uri uri
-                          'diagnostics diags)))
-
 (define ((error-diagnostics src) exn)
   (define msg (exn-message exn))
   (cond

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -33,6 +33,7 @@
     (define hovers (make-interval-map))
     (define docs (make-interval-map))
     (define symbols (make-interval-map))
+    (define requires '())
     ;; decl -> (set pos ...)
     (define sym-decls (make-interval-map))
     ;; pos -> decl
@@ -43,12 +44,16 @@
     (define/public (get-hovers) hovers)
     (define/public (get-docs) docs)
     (define/public (get-symbols) symbols)
+    (define/public (get-requires) requires)
     (define/public (get-sym-decls) sym-decls)
     (define/public (get-sym-bindings) sym-bindings)
     ;; Overrides
     (define/override (syncheck:find-source-object stx)
       (and (equal? src (syntax-source stx))
            src))
+    ;; Track requires
+    (define/override (syncheck:add-require-open-menu text start finish file)
+      (set! requires (set-add requires file)))
     ;; Mouse-over status
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       ;; Infer a length of 1 for zero-length ranges in the document.

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -72,7 +72,7 @@
                                    (url-query url)
                                    url-tag)
                          url))
-        (interval-map-set! docs start finish (url->string url2))))
+        (interval-map-set! docs start finish (list (url->string url2) def-tag))))
     ;; References
     (define/override (syncheck:add-arrow/name-dup start-src-obj start-left start-right
                                                   end-src-obj end-left end-right

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -1,0 +1,27 @@
+#lang racket/base
+
+(require scribble/blueboxes
+         racket/string)
+
+(define the-bluebox-cache (make-blueboxes-cache #f))
+
+(define (find-containing-paren pos text)
+  (define l (string-length text))
+  (cond
+    [(>= pos l) #f]
+    [else
+     (let loop ([i pos] [p 0])
+       (cond
+         [(< i 0) #f]
+         [(or (char=? (string-ref text i) #\() (char=? (string-ref text i) #\[))
+          (if (> p 0) (loop (- i 1) (- p 1)) i)]
+         [(or (char=? (string-ref text i) #\)) (char=? (string-ref text i) #\]))
+          (loop (- i 1) (+ p 1))]
+         [else (loop (- i 1) p)]))]))    
+
+(define (get-docs-for-tag tag)
+  (define strs (fetch-blueboxes-strs tag #:blueboxes-cache the-bluebox-cache))
+  (string-join (list-tail strs 1) "\n"))
+
+(provide find-containing-paren
+         get-docs-for-tag)

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -52,7 +52,7 @@
       [(string-prefix? (list-ref strs i) "(") (loop strs (+ i 1))]
       [else i])))
   (cond [index (list (take strs index) (string-join (if index (drop strs index) strs) "\n"))]
-        [else (list strs)]))
+        [else (list strs #f)]))
 
 (provide find-containing-paren
          get-docs-for-tag

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -7,10 +7,7 @@
          racket/list
          setup/collects
          racket/string
-         scribble/xref
-         "msg-io.rkt"
-         racket/format
-         "responses.rkt")
+         scribble/xref)
 
 (define the-bluebox-cache (make-blueboxes-cache #t))
 (define pkg-cache (make-hash))

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -51,7 +51,8 @@
       [(>= i (length strs)) #f]
       [(string-prefix? (list-ref strs i) "(") (loop strs (+ i 1))]
       [else i])))
-  (list (take strs index) (string-join (drop strs index) "\n")))
+  (cond [index (list (take strs index) (string-join (if index (drop strs index) strs) "\n"))]
+        [else (list strs)]))
 
 (provide find-containing-paren
          get-docs-for-tag

--- a/methods.rkt
+++ b/methods.rkt
@@ -61,6 +61,8 @@
        (shutdown id)]
       ["textDocument/hover"
        (text-document/hover id params)]
+      ["textDocument/signatureHelp"
+       (text-document/signatureHelp id params)]
       ["textDocument/definition"
        (text-document/definition id params)]
       ["textDocument/documentHighlight"
@@ -110,6 +112,7 @@
                'hoverProvider #t
                'definitionProvider #t
                'referencesProvider #t
+               'signatureHelpProvider (hasheq 'triggerCharacters (list " "))
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t

--- a/methods.rkt
+++ b/methods.rkt
@@ -112,7 +112,7 @@
                'hoverProvider #t
                'definitionProvider #t
                'referencesProvider #t
-               'signatureHelpProvider (hasheq 'triggerCharacters (list " "))
+               'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")"))
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t

--- a/responses.rkt
+++ b/responses.rkt
@@ -21,6 +21,13 @@
           'id id
           'error err*))
 
+;; Constructor for a response object representing diagnostics.
+(define (diagnostics-message uri diags)
+  (hasheq 'jsonrpc "2.0"
+          'method "textDocument/publishDiagnostics"
+          'params (hasheq 'uri uri
+                          'diagnostics diags)))
+
 (provide
  (contract-out
   [success-response
@@ -28,4 +35,6 @@
   [error-response
    (->* ((or/c number? string? (json-null)) number? string?)
         (any/c)
-        jsexpr?)]))
+        jsexpr?)]
+  [diagnostics-message
+   (string? list? . -> . jsexpr?)]))

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -182,7 +182,7 @@
                              [else #f])]))
               (cond [tag
                      (match-define (list sigs docs) (get-docs-for-tag tag))
-                     (hasheq 'signatures (map (lambda sig (hasheq 'label sig 'documentation docs)) sigs))]
+                     (hasheq 'signatures (map (lambda sig (hasheq 'label sig 'documentation (or docs (json-null)))) sigs))]
                     [else (json-null)])]
              [else (json-null)]))
      (success-response id result)]

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -9,9 +9,8 @@
          racket/match
          racket/string
          racket/set
-         racket/gui
-         syntax-color/module-lexer
-         syntax-color/racket-lexer
+         racket/dict
+         racket/format
          "append-message.rkt"
          "check-syntax.rkt"
          "error-codes.rkt"

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -140,8 +140,8 @@
      (define pos (line/char->pos doc-text line ch))
      (define-values (start end text)
        (interval-map-ref/bounds hovers pos #f))
-     (define-values (link tag)
-       (interval-map-ref (send doc-trace get-docs) pos #f))
+     (match-define (list link tag)
+       (interval-map-ref (send doc-trace get-docs) pos (list #f #f)))
      (define result
        (cond [text
               (hasheq 'contents (if link (~a text " - [docs](" (~a "https://docs.racket-lang.org/" (last (string-split link "/doc/"))) ")") text)
@@ -381,6 +381,7 @@
   [did-close! (jsexpr? . -> . void?)]
   [did-change! (jsexpr? . -> . void?)]
   [hover (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
+  [signatureHelp (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [definition (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [document-highlight (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [references (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -89,7 +89,7 @@
   (define path (uri->path uri))
   (define doc-text (new racket:text%))
   (send doc-text insert text 0)
-  (define trace (check-syntax path doc-text))
+  (define trace (check-syntax path doc-text #f))
   (hash-set! open-docs (string->symbol uri) (doc doc-text trace)))
 
 (define (did-close! params)
@@ -122,8 +122,8 @@
     ;; set. See 'append-message.rkt' for more info.
     (unless (hash-ref params skip-syncheck #f)
       (define path (uri->path uri))
-      (define trace (check-syntax path doc-text))
-      (set-doc-trace! this-doc trace))))
+      (check-syntax path doc-text (doc-trace this-doc))))
+  (void))
 
 ;; Hover request
 ;; Returns an object conforming to the Hover interface, to

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -133,28 +133,28 @@
 ;; Returns an object conforming to the Hover interface, to
 ;; be used as the result of the response message.
 (define (hover id params)
-    (match params
+  (match params
     [(hash-table ['textDocument (DocIdentifier #:uri uri)]
-                  ['position (Pos #:line line #:char ch)])
-  (unless (uri-is-path? uri)
-    (error 'hover "uri is not a path"))
-  (match-define (doc doc-text doc-trace)
-    (hash-ref open-docs (string->symbol uri)))
-  (define hovers (send doc-trace get-hovers))
-  (define pos (line/char->pos doc-text line ch))
-  (define-values (start end text)
-    (interval-map-ref/bounds hovers pos #f))
-  (match-define (list link tag)
-    (interval-map-ref (send doc-trace get-docs) pos (list #f #f)))
-  (define result
-    (cond [text
-          (hasheq 'contents (if link (~a text " - [docs](" (~a "https://docs.racket-lang.org/" (last (string-split link "/doc/"))) ")") text)
-                  'range (Range #:start (abs-pos->Pos doc-text start)
-                                #:end   (abs-pos->Pos doc-text end)))]
-          [else (hasheq 'contents empty)]))
-  (success-response id result)]
-[_
-  (error-response id INVALID-PARAMS "textDocument/hover failed")]))
+                 ['position (Pos #:line line #:char ch)])
+     (unless (uri-is-path? uri)
+       (error 'hover "uri is not a path"))
+     (match-define (doc doc-text doc-trace)
+       (hash-ref open-docs (string->symbol uri)))
+     (define hovers (send doc-trace get-hovers))
+     (define pos (line/char->pos doc-text line ch))
+     (define-values (start end text)
+       (interval-map-ref/bounds hovers pos #f))
+     (match-define (list link tag)
+       (interval-map-ref (send doc-trace get-docs) pos (list #f #f)))
+     (define result
+       (cond [text
+              (hasheq 'contents (if link (~a text " - [docs](" (~a "https://docs.racket-lang.org/" (last (string-split link "/doc/"))) ")") text)
+                      'range (Range #:start (abs-pos->Pos doc-text start)
+                                    #:end   (abs-pos->Pos doc-text end)))]
+             [else (hasheq 'contents empty)]))
+     (success-response id result)]
+    [_
+     (error-response id INVALID-PARAMS "textDocument/hover failed")]))
 
 ;; Signature Help request
 (define (signatureHelp id params)


### PR DESCRIPTION
Uses scribble/blueboxes to provide bluebox docs:

https://user-images.githubusercontent.com/5150427/112769677-88c4a600-8fdf-11eb-9888-a8bccda735d9.mp4

In order to provide this while the user is still writing, and also for a better overall experience, this PR also caches traces so that if subsequent edits cause errors the rest of the useful trace info (requires, hovers, definitions, ...) are not lost. Trace interval maps are expanded or contracted on edits so symbols are persistently tracked correctly.

In order to provide docs on symbols that have not yet been resolved (due to incomplete expressions, etc), I also moved the symbol enumeration from textDocument/symbols to `(check-syntax)` so that they can be used by other handlers.