### PR TITLE
Provide textDocument/onTypeFormatting

### DIFF
--- a/methods.rkt
+++ b/methods.rkt
@@ -75,6 +75,8 @@
        (text-document/formatting! id params)]
       ["textDocument/rangeFormatting"
        (text-document/range-formatting! id params)]
+      ["textDocument/onTypeFormatting"
+       (text-document/on-type-formatting! id params)]
       [_
        (eprintf "invalid request for method ~v\n" method)
        (define err (format "The method ~v was not found" method))
@@ -116,7 +118,9 @@
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t
-               'documentRangeFormattingProvider #t))
+               'documentRangeFormattingProvider #t
+               'documentOnTypeFormattingProvider (hasheq 'firstTriggerCharacter ")" 'moreTriggerCharacter (list "\n"))))
+
      (define resp (success-response id (hasheq 'capabilities server-capabilities)))
      (set! already-initialized? #t)
      resp]

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -355,7 +355,7 @@
     [_
      (error-response id INVALID-PARAMS "textDocument/rangeFormatting failed")]))
 
-;; Full document formatting request
+;; On-type formatting request
 (define (on-type-formatting! id params)
   (match params
     ;; We're ignoring 'options for now
@@ -414,7 +414,7 @@
      (define span (- current-spaces desired-spaces))
      (send doc-text delete line-start (+ line-start span))
      (TextEdit #:range (Range #:start (Pos #:line line #:char 0)
-                      #:end   (Pos #:line line #:char span))
+                              #:end   (Pos #:line line #:char span))
                #:newText "")]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -317,10 +317,10 @@
        (hash-ref open-docs (string->symbol uri)))
      (define end-pos (send doc-text last-position))
      (range-formatting!
-       id
-       (hash-set params
-                 'range (Range #:start (abs-pos->Pos doc-text 0)
-                               #:end (abs-pos->Pos doc-text end-pos))))]
+      id
+      (hash-set params
+                'range (Range #:start (abs-pos->Pos doc-text 0)
+                              #:end (abs-pos->Pos doc-text end-pos))))]
     [_
      (error-response id INVALID-PARAMS "textDocument/formatting failed")]))
 
@@ -355,6 +355,34 @@
     [_
      (error-response id INVALID-PARAMS "textDocument/rangeFormatting failed")]))
 
+;; Full document formatting request
+(define (on-type-formatting! id params)
+  (match params
+    ;; We're ignoring 'options for now
+    [(hash-table ['textDocument (DocIdentifier #:uri uri)]
+                 ['position (Pos #:line line #:char char)]
+                 ['ch ch])
+     (match-define (doc doc-text doc-trace)
+       (hash-ref open-docs (string->symbol uri)))
+     (define pos (- (line/char->pos doc-text line char) 1))
+     (define range
+       (match ch
+         ["\n"
+          (Range 
+           #:start (abs-pos->Pos doc-text (send doc-text paragraph-start-position line)) 
+           #:end (abs-pos->Pos doc-text (send doc-text paragraph-end-position line)))]
+         [")"
+          (Range
+           #:start (abs-pos->Pos doc-text (or (find-containing-paren pos (send doc-text get-text)) 0))
+           #:end (abs-pos->Pos doc-text pos))]))
+     
+     (range-formatting!
+      id
+      (hash-set params
+                'range range))]
+    [_
+     (error-response id INVALID-PARAMS "textDocument/onTypeformatting failed")]))
+
 ;; Returns a TextEdit, or #f if the line is already correct.
 (define (indent-line! doc-text indenter line)
   (define line-start (send doc-text paragraph-start-position line))
@@ -386,7 +414,7 @@
      (define span (- current-spaces desired-spaces))
      (send doc-text delete line-start (+ line-start span))
      (TextEdit #:range (Range #:start (Pos #:line line #:char 0)
-                              #:end   (Pos #:line line #:char span))
+                      #:end   (Pos #:line line #:char span))
                #:newText "")]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -403,4 +431,5 @@
   [references (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [document-symbol (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
   [formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
-  [range-formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]))
+  [range-formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]
+  [on-type-formatting! (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]))


### PR DESCRIPTION
Formats entire s-expressions when closing blocks and moves indentation to the correct level when the user starts a new line, when "Format On Typing" is available and enabled in the user's editor.

https://user-images.githubusercontent.com/5150427/113434327-f84ee280-939d-11eb-872f-dee9383a8170.mp4

This and auto-completion are currently a bit sluggish in practice because the language server must synchronously re-check syntax right when the user types, which blocks these providers. I have an experimental multi-threading branch I'm working on now that should fix this.