### PR TITLE
Various fixes, proper Typed Racket support

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -191,7 +191,7 @@
   (port-count-lines! in)
   (define lexer (get-lexer in))
   (define symbols (send trace get-symbols))
-  (interval-map-remove! symbols 0 (string-length text))
+  (interval-map-remove! symbols 0 (+ (string-length text) 1))
   (for ([lst (in-port (lexer-wrap lexer) in)] #:when (set-member? '(constant string symbol) (first (rest lst))))
     (match-define (list text type paren? start end) lst)
     (interval-map-set! symbols start end (list text type)))

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -232,11 +232,10 @@
   (match-define-values
     (_ _ _ _ _ _ lexer)
     (module-lexer in 0 #f))
-  (if (procedure? lexer) ;; TODO: Is this an issue with module-lexer docs?
-      lexer
-      (if (eq? lexer 'no-lang-line)
-          racket-lexer
-          (error 'get-lexer "~v" lexer))))
+  (cond 
+    [(procedure? lexer) lexer]
+    [(eq? lexer 'no-lang-line) racket-lexer]
+    [(eq? lexer 'before-lang-line) racket-lexer]))
 
 (provide
  (contract-out

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -56,7 +56,13 @@
   (when (and (list? data) (not (empty? data)) (syntax? (car data)))
     (define prop (syntax-property (car data) 'mouse-over-tooltips))
     (when (and prop (list? prop) (not (empty? prop)))
-      (match-define (vector _ start end msg) (car prop))
+      (define-values (start end msg)
+        (match prop
+          [(list (vector _ start _ _) (vector _ _ end msg))
+           (values start end msg)]
+          [(list (vector _ start end msg))
+           (values start end msg)]
+          [else (values #f #f #f)]))
       (when (string? msg)
         (list (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text start) #:end (abs-pos->Pos doc-text end))
                           #:severity Diag-Error

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -71,9 +71,9 @@
                                              #f)]
                                         [else 
                                          (list->set (set-map decl-set (lambda (d-range) 
-                                                             (if (> (car d-range) after)
-                                                                 (cons (+ (car d-range) amt) (+ (cdr d-range) amt))
-                                                                 d-range))))]))
+                                                                        (if (> (car d-range) after)
+                                                                            (cons (+ (car d-range) amt) (+ (cdr d-range) amt))
+                                                                            d-range))))]))
                        (when result
                          (interval-map-set! int-map (car range) (cdr range) result)))))
     ;; Getters
@@ -164,22 +164,16 @@
      ;; This is very close to DrRacket's behavior:  it also has no source location to work with,
      ;; however it simply doesn't highlight any code.
      (define silly-range
-      (Range #:start (Pos #:line 0 #:char 0) #:end (Pos #:line 0 #:char 0)))
+       (Range #:start (Pos #:line 0 #:char 0) #:end (Pos #:line 0 #:char 0)))
      (list (Diagnostic #:range silly-range
                        #:severity Diag-Error
                        #:source "Racket"
                        #:message msg))]
-      [else (error 'error-diagnostics "unexpected failure: ~a" exn)]))
+    [else (error 'error-diagnostics "unexpected failure: ~a" exn)]))
 
-;; XXX Want to use read-language for this, but can't just assume this
-;; XXX is the first line because there might be comments.
-;; XXX Look into ways to efficiently read from doc-text like a port.
-;; XXX (This would make get-lexer faster too.)
-;; XXX For now, use default indentation for everything (until we support
-;; XXX custom #langs).
 (define (get-indenter doc-text)
-  (define lang-info (read-language (open-input-string (send doc-text get-text))))
-  (lang-info 'drracket:indentation #f))
+  (define lang-info (read-language (open-input-string (send doc-text get-text)) (lambda () #f)))
+  (and lang-info (lang-info 'drracket:indentation #f)))
 
 (define (check-syntax src doc-text trace)
   (define indenter (get-indenter doc-text))

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -7,144 +7,20 @@
          racket/match
          racket/set
          racket/logging
-         racket/dict
          racket/list
          racket/string
-         racket/format
          syntax-color/module-lexer
          syntax-color/racket-lexer
          net/url
          syntax/modread
          (only-in net/url path->url url->string)
-         "interfaces.rkt"
          "msg-io.rkt"
          "responses.rkt"
-         "autocomplete.rkt")
+         "interfaces.rkt"
+         "autocomplete.rkt"
+         "doc-trace.rkt")
 
 (define path->uri (compose url->string path->url))
-(struct Decl (require? left right) #:transparent)
-
-(define Diag-Error 1)
-(define Diag-Warning 2)
-(define Diag-Information 3)
-(define Diag-Hint 4)
-
-(define build-trace%
-  (class (annotations-mixin object%)
-    (init-field src doc-text indenter)
-    (define warn-diags (mutable-seteq))
-    (define hovers (make-interval-map))
-    (define docs (make-interval-map))
-    (define symbols (make-interval-map))
-    (define completions (list))
-    (define requires '())
-    ;; decl -> (set pos ...)
-    (define sym-decls (make-interval-map))
-    ;; pos -> decl
-    (define sym-bindings (make-interval-map))
-    (define/public (reset)
-      (set-clear! warn-diags)
-      (set! hovers (make-interval-map))
-      (set! docs (make-interval-map))
-      (set! sym-decls (make-interval-map))
-      (set! sym-bindings (make-interval-map))
-      (set! symbols (make-interval-map))
-      (set! requires '()))
-    (define/public (expand start end)
-      (define inc (- end start))
-      (move-interior-intervals sym-decls (- start 1) inc)
-      (move-interior-intervals sym-bindings (- start 1) inc)
-      (map (lambda (int-map) (interval-map-expand! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))
-    (define/public (contract start end)
-      (define dec (- start end))
-      (move-interior-intervals sym-decls end dec)
-      (move-interior-intervals sym-bindings end dec)
-      (map (lambda (int-map) (interval-map-contract! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))
-    ;; some intervals are held inside of the interval maps... so we need to expand/contract these manually
-    (define/private (move-interior-intervals int-map after amt)
-      (dict-for-each int-map
-                     (lambda (range decl-set)
-                       (define is-decl (Decl? decl-set))
-                       (define result (cond 
-                                        [is-decl
-                                         (define d-range (cons (Decl-left decl-set) (Decl-right decl-set)))
-                                         (if (> (car d-range) after) 
-                                             (Decl (Decl-require? decl-set) (+ (car d-range) amt) (+ (cdr d-range) amt))
-                                             #f)]
-                                        [else 
-                                         (list->set (set-map decl-set (lambda (d-range) 
-                                                                        (if (> (car d-range) after)
-                                                                            (cons (+ (car d-range) amt) (+ (cdr d-range) amt))
-                                                                            d-range))))]))
-                       (when result
-                         (interval-map-set! int-map (car range) (cdr range) result)))))
-    ;; Getters
-    (define/public (get-indenter) indenter)
-    (define/public (get-warn-diags) warn-diags)
-    (define/public (get-hovers) hovers)
-    (define/public (get-docs) docs)
-    (define/public (get-symbols) symbols)
-    (define/public (get-completions) completions)
-    (define/public (set-completions new-completions) (set! completions new-completions))
-    (define/public (get-requires) requires)
-    (define/public (get-sym-decls) sym-decls)
-    (define/public (get-sym-bindings) sym-bindings)
-    ;; Overrides
-    (define/override (syncheck:find-source-object stx)
-      (and (equal? src (syntax-source stx))
-           src))
-    ;; Track requires
-    (define/override (syncheck:add-require-open-menu text start finish file)
-      (set! requires (set-add requires file)))
-    ;; Mouse-over status
-    (define/override (syncheck:add-mouse-over-status src-obj start finish text)
-      ;; Infer a length of 1 for zero-length ranges in the document.
-      ;; XXX This might not exactly match the behavior in DrRacket.
-      (when (= start finish)
-        (set! finish (add1 finish)))
-      (interval-map-set! hovers start finish text))
-    ;; Docs
-    (define/override (syncheck:add-docs-menu text start finish id label path def-tag url-tag)
-      (when url
-        (when (= start finish)
-          (set! finish (add1 finish)))
-        (define url (path->url path))
-        (define url2 (if url-tag
-                         (make-url (url-scheme url)
-                                   (url-user url)
-                                   (url-host url)
-                                   (url-port url)
-                                   (url-path-absolute? url)
-                                   (url-path url)
-                                   (url-query url)
-                                   url-tag)
-                         url))
-        (interval-map-set! docs start finish (list (url->string url2) def-tag))))
-    ;; References
-    (define/override (syncheck:add-arrow/name-dup start-src-obj start-left start-right
-                                                  end-src-obj end-left end-right
-                                                  actual? phase-level
-                                                  require-arrow? name-dup?)
-      (when (= start-left start-right)
-        (set! start-right (add1 start-right)))
-      (when (= end-left end-right)
-        (set! end-right (add1 end-right)))
-      ;; Mapping from doc declaration to set of bindings.
-      (define prev-bindings (interval-map-ref sym-decls start-left set))
-      (define new-bindings (set-add prev-bindings (cons end-left end-right)))
-      (interval-map-set! sym-decls start-left start-right new-bindings)
-      ;; Mapping from binding to declaration.
-      (define new-decl (Decl require-arrow? start-left start-right))
-      (interval-map-set! sym-bindings end-left end-right new-decl))
-    ;; Unused requires
-    (define/override (syncheck:add-unused-require src left right)
-      (define diag (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text left)
-                                              #:end   (abs-pos->Pos doc-text right))
-                               #:severity Diag-Information
-                               #:source "Racket"
-                               #:message "unused require"))
-      (set-add! warn-diags diag))
-    (super-new)))
 
 (define ((error-diagnostics src) exn)
   (define msg (exn-message exn))
@@ -275,7 +151,4 @@
 
 (provide
  (contract-out
-  [struct Decl ([require? any/c]
-                [left exact-nonnegative-integer?]
-                [right exact-nonnegative-integer?])]
   [check-syntax (-> any/c (is-a?/c text%) (or/c #f (is-a?/c build-trace%)) (is-a?/c build-trace%))]))

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -177,9 +177,9 @@
 
 (define (check-typed-racket-log doc-text log)
   (match-define (vector _ msg data _) log)
-  (when (and (list? data) (syntax? (car data)))
+  (when (and (list? data) (not (empty? data)) (syntax? (car data)))
     (define prop (syntax-property (car data) 'mouse-over-tooltips))
-    (when (and prop (list? prop))
+    (when (and prop (list? prop) (not (empty? prop)))
       (match-define (vector _ start end msg) (car prop))
       (when (string? msg)
         (list (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text start) #:end (abs-pos->Pos doc-text end))

--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -1,0 +1,135 @@
+#lang racket/base
+(require racket/class
+         racket/dict
+         racket/set
+         racket/contract/base
+         drracket/check-syntax
+         data/interval-map
+         net/url
+         "interfaces.rkt"
+         "responses.rkt")
+
+(struct Decl (require? left right) #:transparent)
+
+(define build-trace%
+  (class (annotations-mixin object%)
+    (init-field src doc-text indenter)
+    (define warn-diags (mutable-seteq))
+    (define hovers (make-interval-map))
+    (define docs (make-interval-map))
+    (define symbols (make-interval-map))
+    (define completions (list))
+    (define requires '())
+    ;; decl -> (set pos ...)
+    (define sym-decls (make-interval-map))
+    ;; pos -> decl
+    (define sym-bindings (make-interval-map))
+    (define/public (reset)
+      (set-clear! warn-diags)
+      (set! hovers (make-interval-map))
+      (set! docs (make-interval-map))
+      (set! sym-decls (make-interval-map))
+      (set! sym-bindings (make-interval-map))
+      (set! symbols (make-interval-map))
+      (set! requires '()))
+    (define/public (expand start end)
+      (define inc (- end start))
+      (move-interior-intervals sym-decls (- start 1) inc)
+      (move-interior-intervals sym-bindings (- start 1) inc)
+      (map (lambda (int-map) (interval-map-expand! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))
+    (define/public (contract start end)
+      (define dec (- start end))
+      (move-interior-intervals sym-decls end dec)
+      (move-interior-intervals sym-bindings end dec)
+      (map (lambda (int-map) (interval-map-contract! int-map start end)) (list hovers docs symbols sym-decls sym-bindings)))
+    ;; some intervals are held inside of the interval maps... so we need to expand/contract these manually
+    (define/private (move-interior-intervals int-map after amt)
+      (dict-for-each int-map
+                     (lambda (range decl-set)
+                       (define is-decl (Decl? decl-set))
+                       (define result (cond 
+                                        [is-decl
+                                         (define d-range (cons (Decl-left decl-set) (Decl-right decl-set)))
+                                         (if (> (car d-range) after) 
+                                             (Decl (Decl-require? decl-set) (+ (car d-range) amt) (+ (cdr d-range) amt))
+                                             #f)]
+                                        [else 
+                                         (list->set (set-map decl-set (lambda (d-range) 
+                                                                        (if (> (car d-range) after)
+                                                                            (cons (+ (car d-range) amt) (+ (cdr d-range) amt))
+                                                                            d-range))))]))
+                       (when result
+                         (interval-map-set! int-map (car range) (cdr range) result)))))
+    ;; Getters
+    (define/public (get-indenter) indenter)
+    (define/public (get-warn-diags) warn-diags)
+    (define/public (get-hovers) hovers)
+    (define/public (get-docs) docs)
+    (define/public (get-symbols) symbols)
+    (define/public (get-completions) completions)
+    (define/public (set-completions new-completions) (set! completions new-completions))
+    (define/public (get-requires) requires)
+    (define/public (get-sym-decls) sym-decls)
+    (define/public (get-sym-bindings) sym-bindings)
+    ;; Overrides
+    (define/override (syncheck:find-source-object stx)
+      (and (equal? src (syntax-source stx))
+           src))
+    ;; Track requires
+    (define/override (syncheck:add-require-open-menu text start finish file)
+      (set! requires (set-add requires file)))
+    ;; Mouse-over status
+    (define/override (syncheck:add-mouse-over-status src-obj start finish text)
+      ;; Infer a length of 1 for zero-length ranges in the document.
+      ;; XXX This might not exactly match the behavior in DrRacket.
+      (when (= start finish)
+        (set! finish (add1 finish)))
+      (interval-map-set! hovers start finish text))
+    ;; Docs
+    (define/override (syncheck:add-docs-menu text start finish id label path def-tag url-tag)
+      (when url
+        (when (= start finish)
+          (set! finish (add1 finish)))
+        (define url (path->url path))
+        (define url2 (if url-tag
+                         (make-url (url-scheme url)
+                                   (url-user url)
+                                   (url-host url)
+                                   (url-port url)
+                                   (url-path-absolute? url)
+                                   (url-path url)
+                                   (url-query url)
+                                   url-tag)
+                         url))
+        (interval-map-set! docs start finish (list (url->string url2) def-tag))))
+    ;; References
+    (define/override (syncheck:add-arrow/name-dup start-src-obj start-left start-right
+                                                  end-src-obj end-left end-right
+                                                  actual? phase-level
+                                                  require-arrow? name-dup?)
+      (when (= start-left start-right)
+        (set! start-right (add1 start-right)))
+      (when (= end-left end-right)
+        (set! end-right (add1 end-right)))
+      ;; Mapping from doc declaration to set of bindings.
+      (define prev-bindings (interval-map-ref sym-decls start-left set))
+      (define new-bindings (set-add prev-bindings (cons end-left end-right)))
+      (interval-map-set! sym-decls start-left start-right new-bindings)
+      ;; Mapping from binding to declaration.
+      (define new-decl (Decl require-arrow? start-left start-right))
+      (interval-map-set! sym-bindings end-left end-right new-decl))
+    ;; Unused requires
+    (define/override (syncheck:add-unused-require src left right)
+      (define diag (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text left)
+                                              #:end   (abs-pos->Pos doc-text right))
+                               #:severity Diag-Information
+                               #:source "Racket"
+                               #:message "unused require"))
+      (set-add! warn-diags diag))
+    (super-new)))
+
+(provide build-trace%
+         (contract-out
+          [struct Decl ([require? any/c]
+                        [left exact-nonnegative-integer?]
+                        [right exact-nonnegative-integer?])]))

--- a/responses.rkt
+++ b/responses.rkt
@@ -21,6 +21,11 @@
           'id id
           'error err*))
 
+(define Diag-Error 1)
+(define Diag-Warning 2)
+(define Diag-Information 3)
+(define Diag-Hint 4)
+
 ;; Constructor for a response object representing diagnostics.
 (define (diagnostics-message uri diags)
   (hasheq 'jsonrpc "2.0"
@@ -29,6 +34,10 @@
                           'diagnostics diags)))
 
 (provide
+ Diag-Error
+ Diag-Warning
+ Diag-Information
+ Diag-Hint
  (contract-out
   [success-response
    ((or/c number? string?) jsexpr? . -> . jsexpr?)]

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -362,15 +362,14 @@
            (let ([r-text (new racket:text%)]) (send r-text insert (send doc-text get-text)) r-text)
            (send doc-text copy-self)))
      (define results
-       (if indenter 
+       (if (eq? indenter 'missing) (json-null)
            (let loop ([line start-line])
              (if (> line end-line)
                  null
                  (let ([edit (indent-line! mut-doc-text indenter line)])
                    (if edit
                        (cons edit (loop (add1 line)))
-                       (loop (add1 line))))))
-           (json-null)))
+                       (loop (add1 line))))))))
      (success-response id results)]
     [_
      (error-response id INVALID-PARAMS "textDocument/rangeFormatting failed")]))

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -19,7 +19,7 @@
          "responses.rkt"
          "symbol-kinds.rkt"
          "docs-helpers.rkt"
-         "autocomplete.rkt")
+         "doc-trace.rkt")
 
 (struct doc (text trace) #:transparent #:mutable)
 

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -362,13 +362,15 @@
            (let ([r-text (new racket:text%)]) (send r-text insert (send doc-text get-text)) r-text)
            (send doc-text copy-self)))
      (define results
-       (let loop ([line start-line])
-         (if (> line end-line)
-             null
-             (let ([edit (indent-line! mut-doc-text indenter line)])
-               (if edit
-                   (cons edit (loop (add1 line)))
-                   (loop (add1 line)))))))
+       (if indenter 
+           (let loop ([line start-line])
+             (if (> line end-line)
+                 null
+                 (let ([edit (indent-line! mut-doc-text indenter line)])
+                   (if edit
+                       (cons edit (loop (add1 line)))
+                       (loop (add1 line))))))
+           (json-null)))
      (success-response id results)]
     [_
      (error-response id INVALID-PARAMS "textDocument/rangeFormatting failed")]))


### PR DESCRIPTION
Fixes #30, Fixes #28, Fixes #12

I don't really know if there's a more "correct" way to catch the typed racket errors, but they weren't being caught by all the existing handlers and all I came up with by spelunking drracket and typed-racket repositories was to intercept logs and nab them that way.

![image](https://user-images.githubusercontent.com/5150427/113471663-14449980-941b-11eb-91e8-613c8689518a.png)

Handling the #lang lines a little nicer has lovely side effects, such as properly reporting when a module is missing instead of the langserver just going into an unusable state.

![image](https://user-images.githubusercontent.com/5150427/113472021-73a3a900-941d-11eb-84c2-617c690e5ec3.png)
