### PR TITLE
Provide textDocument/rename and prepareRename

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,15 @@ You may need to restart your LSP runtime or your editor for `racket-langserver` 
   - *Note:* Currently only considers references within the current file.
 - **Document Highlight** (textDocument/documentHighlight)
 - **Diagnostics** (textDocument/publishDiagnostics)
-- **Code Formatting** (textDocument/formatting & textDocument/rangeFormatting)
+- **Code Formatting** (textDocument/formatting & textDocument/rangeFormatting & textDocument/onTypeFormatting)
+- **Signature Help** (textDocument/signatureHelp)
+- **Rename** (textDocument/rename & textDocument/prepareRename)
+  - *Note:* Currently only allows renaming symbols defined within the current file.
+- **Code completion** (textDocument/completion)
 
 #### *Work in Progress:*
 
 - **Document Outline** (textDocument/documentSymbol)
-
-#### *Would be Nice:*
-
-- **Rename** (textDocument/rename)
-- **Code completion** (textDocument/completion)
 
 ## Notes for Contributers
 

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -97,6 +97,8 @@
   (for ([lst (in-port (lexer-wrap lexer) in)] #:when (set-member? '(constant string symbol) (first (rest lst))))
     (match-define (list text type paren? start end) lst)
     (interval-map-set! symbols start end (list text type)))
+  (when trace
+    (send trace set-symbols symbols))
   
   ;; Rewind input port and read syntax
   (set! in (open-input-string text))
@@ -126,7 +128,10 @@
                            (error-diagnostics src)])
             (define stx (expand (with-module-reading-parameterization
                                   (λ () (read-syntax src in)))))
-            (send new-trace set-completions (append (set->list (walk stx)) (set->list (walk-module stx))))
+            (define completions (append (set->list (walk stx)) (set->list (walk-module stx))))
+            (send new-trace set-completions completions)
+            (when trace
+              (send trace set-completions completions))
             (add-syntax stx)
             (set! valid #t)
             (done)

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -128,6 +128,9 @@
                            (error-diagnostics src)])
             (define stx (expand (with-module-reading-parameterization
                                   (λ () (read-syntax src in)))))
+            ;; reading and expanding succeeded, clear out any syntax errors before the
+            ;; heavy stuff in order to be responsive to the user
+            (display-message/flush (diagnostics-message (path->uri src) (list)))
             (define completions (append (set->list (walk stx)) (set->list (walk-module stx))))
             (send new-trace set-completions completions)
             (when trace

--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -19,7 +19,7 @@
     (define docs (make-interval-map))
     (define symbols (make-interval-map))
     (define completions (list))
-    (define requires '())
+    (define requires (make-interval-map))
     ;; decl -> (set pos ...)
     (define sym-decls (make-interval-map))
     ;; pos -> decl
@@ -31,7 +31,7 @@
       (set! sym-decls (make-interval-map))
       (set! sym-bindings (make-interval-map))
       (set! symbols (make-interval-map))
-      (set! requires '()))
+      (set! requires (make-interval-map)))
     (define/public (expand start end)
       (define inc (- end start))
       (move-interior-intervals sym-decls (- start 1) inc)
@@ -78,7 +78,7 @@
            src))
     ;; Track requires
     (define/override (syncheck:add-require-open-menu text start finish file)
-      (set! requires (set-add requires file)))
+      (interval-map-set! requires start finish file))
     ;; Mouse-over status
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       ;; Infer a length of 1 for zero-length ranges in the document.

--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -66,6 +66,7 @@
     (define/public (get-hovers) hovers)
     (define/public (get-docs) docs)
     (define/public (get-symbols) symbols)
+    (define/public (set-symbols new-symbols) (set! symbols new-symbols))
     (define/public (get-completions) completions)
     (define/public (set-completions new-completions) (set! completions new-completions))
     (define/public (get-requires) requires)

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -5,6 +5,7 @@
          racket/set
          racket/class
          racket/list
+         racket/dict
          setup/collects
          racket/string
          scribble/xref)
@@ -31,7 +32,7 @@
   ;; in drracket/private/syncheck/blueboxes-gui.rkt
   (define xref (load-collections-xref))
   (define mps
-    (for/list ([require-candidate (in-set (send trace get-requires))])
+    (for/list ([(k require-candidate) (in-dict (send trace get-requires))])
       (path->module-path require-candidate #:cache pkg-cache)))
   (for/or ([mp (in-list mps)])
     (define definition-tag (xref-binding->definition-tag xref (list mp (string->symbol id)) #f))

--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -43,4 +43,7 @@
 (define (line/char->pos t line char)
   (+ char (send t paragraph-start-position line)))
 
+(define (start/end->Range t start end)
+  (Range #:start (abs-pos->Pos t start) #:end (abs-pos->Pos t end)))
+
 (provide (all-defined-out))

--- a/methods.rkt
+++ b/methods.rkt
@@ -75,6 +75,8 @@
        (text-document/document-symbol id params)]
       ["textDocument/rename"
        (text-document/rename id params)]
+       ["textDocument/prepareRename"
+       (text-document/prepareRename id params)]
       ["textDocument/formatting"
        (text-document/formatting! id params)]
       ["textDocument/rangeFormatting"
@@ -118,14 +120,14 @@
                'hoverProvider #t
                'definitionProvider #t
                'referencesProvider #t
-               'completionProvider (hasheq 'triggerCharacters (list " " "("))
-               'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")"))
-               'renameProvider #t
+               'completionProvider (hasheq 'triggerCharacters (list "("))
+               'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")" "]"))
+               'renameProvider (hasheq 'prepareProvider #t)
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t
                'documentRangeFormattingProvider #t
-               'documentOnTypeFormattingProvider (hasheq 'firstTriggerCharacter ")" 'moreTriggerCharacter (list "\n"))))
+               'documentOnTypeFormattingProvider (hasheq 'firstTriggerCharacter ")" 'moreTriggerCharacter (list "\n" "]"))))
 
      (define resp (success-response id (hasheq 'capabilities server-capabilities)))
      (set! already-initialized? #t)

--- a/methods.rkt
+++ b/methods.rkt
@@ -115,6 +115,13 @@
                'change TextDocSync-Incremental
                'willSave #f
                'willSaveWaitUntil #f))
+     (define renameProvider
+       (match capabilities
+         [(hash-table ['textDocument 
+                       (hash-table ['rename
+                                    (hash-table ['prepareSupport #t])])])
+          (hasheq 'prepareProvider #t)]
+         [_ #t]))
      (define server-capabilities
        (hasheq 'textDocumentSync sync-options
                'hoverProvider #t
@@ -122,7 +129,7 @@
                'referencesProvider #t
                'completionProvider (hasheq 'triggerCharacters (list "("))
                'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")" "]"))
-               'renameProvider (hasheq 'prepareProvider #t)
+               'renameProvider renameProvider
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t

--- a/methods.rkt
+++ b/methods.rkt
@@ -73,6 +73,8 @@
        (text-document/references id params)]
       ["textDocument/documentSymbol"
        (text-document/document-symbol id params)]
+      ["textDocument/rename"
+       (text-document/rename id params)]
       ["textDocument/formatting"
        (text-document/formatting! id params)]
       ["textDocument/rangeFormatting"
@@ -118,6 +120,7 @@
                'referencesProvider #t
                'completionProvider (hasheq 'triggerCharacters (list " " "("))
                'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")"))
+               'renameProvider #t
                'documentHighlightProvider #t
                'documentSymbolProvider #t
                'documentFormattingProvider #t

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -432,7 +432,7 @@
           (Range 
            #:start (abs-pos->Pos doc-text (send doc-text paragraph-start-position line)) 
            #:end (abs-pos->Pos doc-text (send doc-text paragraph-end-position line)))]
-         [")"
+         [_
           (Range
            #:start (abs-pos->Pos doc-text (or (find-containing-paren pos (send doc-text get-text)) 0))
            #:end (abs-pos->Pos doc-text pos))]))


### PR DESCRIPTION
Effective and expected renaming support. Until more workspace support is added, `prepareRename` rejects any rename requests for symbols not defined in the current file. Leads to more expected behavior than DrRacket in some cases.


https://user-images.githubusercontent.com/5150427/113500185-44527200-94d9-11eb-8257-1e615d3f731a.mp4

Also includes a few other improvements and fixes, such as a fix to signature & autocompletion providing while writing new code and some improvements to trigger characters for certain methods.

