### PR TITLE
Fix messages getting mangled from threads

### DIFF
--- a/msg-io.rkt
+++ b/msg-io.rkt
@@ -24,8 +24,16 @@
   (write-json msg out))
 
 (define (display-message/flush msg [out (current-output-port)])
+  (channel-put in-ch msg))
+
+(define (read-loop in-ch [out (current-output-port)])
+  (define msg (channel-get in-ch))
   (display-message msg out)
-  (flush-output out))
+  (flush-output out)
+  (read-loop in-ch out))
+
+(define in-ch (make-channel))
+(define message-th (thread (lambda () (read-loop in-ch))))
 
 (provide
  verbose-io?


### PR DESCRIPTION
There was a bug with the introduction of #44 causing the language server to sometimes mix together multiple JSON-RPC responses together, which causes that and all future responses to fail. By forcing all requests to go through one thread, this fix ensures the message chunks are always sent in intended order.