### PR TITLE
Add missing dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,10 @@
                "data-lib"
                "drracket-tool-lib"
                "gui-lib"
-               "syntax-color-lib"))
+               "syntax-color-lib"
+               "scribble-lib" ;; for blueboxes (scribble/blueboxes)
+               "racket-index" ;; for cross references (setup/xref)
+               ))
 (define build-deps '("chk"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")
 (define version "1.0")


### PR DESCRIPTION
Error message from `raco setup`:

```
raco setup: undeclared dependency detected
raco setup:   for package: "racket-langserver"
raco setup:   on packages:
raco setup:    "racket-index"
raco setup:    "scribble-lib"
```

More details:

```
raco setup: found undeclared dependency:
raco setup:   mode: run
raco setup:   for package: "racket-langserver"
raco setup:   on package: "scribble-lib"
raco setup:   dependent source: ....../docs-helpers_rkt.zo
raco setup:   used module: (lib "scribble/blueboxes.rkt")
raco setup: found undeclared dependency:
raco setup:   mode: run
raco setup:   for package: "racket-langserver"
raco setup:   on package: "racket-index"
raco setup:   dependent source: ....../docs-helpers_rkt.zo
raco setup:   used module: (lib "setup/xref.rkt")
raco setup: found undeclared dependency:
raco setup:   mode: run
raco setup:   for package: "racket-langserver"
raco setup:   on package: "scribble-lib"
raco setup:   dependent source: ....../docs-helpers_rkt.zo
raco setup:   used module: (lib "scribble/xref.rkt")
```
