### PR TITLE
fix indenting when indenter returns #f

### DIFF
--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -66,8 +66,6 @@
                           #:source "Typed Racket"
                           #:message msg))))))
 
-(define default-indenter ((read-language (open-input-string "#lang racket/base")) 'drracket:indentation #f))
-
 (define (get-indenter doc-text)
   (define lang-info 
     (with-handlers ([exn:fail:read? (lambda (e) 'missing)]
@@ -77,7 +75,7 @@
     [(procedure? lang-info)
      (lang-info 'drracket:indentation #f)]
     [(eq? lang-info 'missing) lang-info]
-    [else default-indenter]))
+    [else #f]))
 
 (define (check-syntax src doc-text trace)
   (define indenter (get-indenter doc-text))

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -497,7 +497,7 @@
             [else i])))
   (define desired-spaces
     (if indenter
-        (indenter doc-text line-start)
+        (or (indenter doc-text line-start) (send doc-text compute-racket-amount-to-indent line-start))
         (send doc-text compute-racket-amount-to-indent line-start)))
   (cond
     [(not (number? desired-spaces)) #f]


### PR DESCRIPTION
Fixes #56 

Also removes the "default indenter" thing because I didn't realize that was fully already handled in the `indent-line!` helper and it wasn't working anyway.