### PR TITLE
fix indenter

### DIFF
--- a/text-document.rkt
+++ b/text-document.rkt
@@ -532,6 +532,7 @@
   (cond
     [(not (number? desired-spaces)) #f]
     [(= current-spaces desired-spaces) #f]
+    [(= line-length 0) #f]
     [(< current-spaces desired-spaces)
      ;; Insert spaces
      (define insert-count (- desired-spaces current-spaces))


### PR DESCRIPTION
originally, we get desired spaces and just applied, but in the case like
the following code:

```rkt
  (define x 1)

  (define y 2)
```

we end up get indent

```rkt
  (define x 1)
  
  (define y 2)
```

which is because we didn't check a line between code might be empty, and
them don't need indent