### PR TITLE
Change signatures label to be a string

### DIFF
--- a/text-document.rkt
+++ b/text-document.rkt
@@ -159,7 +159,7 @@
               (cond [tag
                      (match-define (list sigs docs) (get-docs-for-tag tag))
                      (if sigs
-                         (hasheq 'signatures (map (lambda sig (hasheq 'label sig 'documentation (or docs (json-null)))) sigs))
+                         (hasheq 'signatures (map (lambda (sig) (hasheq 'label sig 'documentation (or docs (json-null)))) sigs))
                          (json-null))]
                     [else (json-null)])]
              [else (json-null)]))


### PR DESCRIPTION
Fixes #70. It appears that the `lambda` had unintentionally missing parenthesis around its argument.