### PR TITLE
Show documentation in hover window

### DIFF
--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -7,7 +7,8 @@
          data/interval-map
          net/url
          "interfaces.rkt"
-         "responses.rkt")
+         "responses.rkt"
+         "docs-helpers.rkt")
 
 (struct Decl (require? id left right) #:transparent)
 
@@ -86,18 +87,12 @@
       (when url
         (when (= start finish)
           (set! finish (add1 finish)))
-        (define url (path->url path))
-        (define url2 (if url-tag
-                         (make-url (url-scheme url)
-                                   (url-user url)
-                                   (url-host url)
-                                   (url-port url)
-                                   (url-path-absolute? url)
-                                   (url-path url)
-                                   (url-query url)
-                                   url-tag)
-                         url))
-        (interval-map-set! docs start finish (list (url->string url2) def-tag))))
+        (define path-url (path->url path))
+        (define link+tag (cond
+                           [url-tag (struct-copy url path-url [fragment url-tag])]
+                           [def-tag (struct-copy url path-url [fragment (def-tag->html-anchor-tag def-tag)])]
+                           [else path-url]))
+        (interval-map-set! docs start finish (list (url->string link+tag) def-tag))))
     (define/override (syncheck:add-jump-to-definition source-obj start end id filename submods)
       (define decl (Decl filename id 0 0))
       (interval-map-set! sym-bindings start (add1 end) decl))

--- a/docs-helpers.rkt
+++ b/docs-helpers.rkt
@@ -7,7 +7,9 @@
          racket/dict
          setup/collects
          racket/string
-         scribble/xref)
+         scribble/xref
+         net/url-string
+         racket/format)
 
 (define the-bluebox-cache (make-blueboxes-cache #t))
 (define pkg-cache (make-hash))
@@ -54,7 +56,54 @@
                [else (list strs #f)])]
         [else (list #f #f)]))
 
+;; Examples:
+;; Input: "file:///C:/Program Files/Racket/doc/reference/module.html#(form._((quote._~23~25kernel)._module))" #f
+;; Output: https://docs.racket-lang.org/reference/module.html#%28form._%28%28quote._%7E23%7E25kernel%29._module%29%29
+;;  (i.e. https://docs.racket-lang.org/ + left trimmed `url`)
+;; Input: "pairs.html#(def._((lib._racket/list..rkt)._add-between))" "C:/Program Files/Racket/doc/reference/strings.html"
+;; Output: https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Flist..rkt%29._add-between%29%29
+;;  (i.e. https://docs.racket-lang.org/ + /reference/ from `docs-path` + `url`)
+(define (make-proper-url-for-online-documentation url [docs-path #f])
+  (define online-docs-url "https://docs.racket-lang.org/")
+  (define (absolute-web-url? url) (and (string-contains? url "://") (not (string-prefix? url "file"))))
+  (define (get-relative-docs-url url) ;; e.g. "reference/module.html#(form._((quote._~23~25kernel)._module))"
+    (last (string-split url #rx"/doc/(racket/)?"))) ; "(racket/)?" in case docs are installed in 'usr/share/doc/racket' on linux
+  (define (strip-off-last-path-segment url) (string-join (drop-right (string-split url "/") 1) "/" #:after-last "/"))
+  (define (encode-url url-string)
+    (define url-struct (string->url url-string))
+    ;; particularly encode chars '(', ')' and '~' from Markdown. Both VSCode's and Atom's Md parsers don't like them in links.
+    (current-url-encode-mode 'unreserved)
+    (define encoded-url (string-replace (url->string url-struct) "~" "%7E"))
+    ;; Rarely, there are `redirecting` links that require putting `&` back in query to work properly
+    (string-replace encoded-url "&amp;" "&"))
+
+  (define encoded-url (encode-url url))
+  (cond
+    [(absolute-web-url? encoded-url) encoded-url]
+    [docs-path
+     (define ending (get-relative-docs-url docs-path))
+     (~a online-docs-url
+         (if (or (string-prefix? encoded-url "#") (zero? (string-length encoded-url)))
+             ending
+             (strip-off-last-path-segment ending))
+         encoded-url)]
+    [else (~a online-docs-url (get-relative-docs-url encoded-url))]))
+
+;; Example: '(def ((quote #%kernel) hasheq)) => "(def._((quote._~23~25kernel)._hasheq))"
+;; mostly a copy of a closed function `anchor-name` in `scribble-lib/scribble/html-render.rkt`
+(define (def-tag->html-anchor-tag v)
+  (define (encode-byte b) (string-append (if (< b 16) "~0" "~") (number->string b 16)))
+  (define (encode-bytes str) (string->bytes/utf-8 (encode-byte (bytes-ref str 0))))
+  (let* ([v (string->bytes/utf-8 (format "~a" v))]
+         [v (regexp-replace* #rx#"[A-Z.]" v #".&")]
+         [v (regexp-replace* #rx#" " v #"._")]
+         [v (regexp-replace* #rx#"\"" v #".'")]
+         [v (regexp-replace* #rx#"[^-a-zA-Z0-9_!+*'()/.,]" v encode-bytes)])
+    (bytes->string/utf-8 v)))
+
 
 (provide find-containing-paren
          get-docs-for-tag
-         id-to-tag)
+         id-to-tag
+         make-proper-url-for-online-documentation
+         def-tag->html-anchor-tag)

--- a/documentation-parser.rkt
+++ b/documentation-parser.rkt
@@ -1,0 +1,290 @@
+#lang racket/base
+(require
+  racket/match
+  racket/string
+  racket/format
+  net/url-string
+  html-parsing
+  racket/function
+  "docs-helpers.rkt")
+
+
+;; ------------------------------------------
+;; Cursor (aka html node tree navigator) is implemented with the Zipper data structure
+;; The idea of its use is borrowed from a similar project: https://github.com/dyoo/wescheme-docs/blob/master/tree-cursor.rkt
+;; Zipper is described in detail in a paper "Functional Pearl. The Zipper" by Gerard Huet
+
+(struct cursor (selected-node lefts parent rights) #:transparent)
+(define (make-cursor tree-node) (cursor tree-node '() #f '()))
+
+(define (cursor-can-go-down? current-cursor)
+  (match current-cursor [(cursor (list fst-child _ ...) _ _ _) #t] [_ #f]))
+(define (cursor-can-go-up? current-cursor)
+  (match current-cursor [(cursor _ _ parent _) #:when parent #t] [_ #f]))
+(define (cursor-can-go-left? current-cursor)
+  (match current-cursor [(cursor _ (list left-sibling _ ...) _ _) #t] [_ #f]))
+(define (cursor-can-go-right? current-cursor)
+  (match current-cursor [(cursor _ _ _ (list right-sibling _ ...)) #t] [_ #f]))
+
+(define (cursor-go-down current-cursor)
+  (match current-cursor
+    [(cursor (list fst-child others ...) _ _ _)
+     (cursor fst-child '() current-cursor others)]
+    [_ (error "Cursor can't move down!")]))
+(define (cursor-go-up current-cursor)
+  (match current-cursor
+    [(cursor selected-node lefts parent rights)
+     (cursor (append (reverse lefts) (cons selected-node rights))
+             (cursor-lefts parent) (cursor-parent parent) (cursor-rights parent))]
+    [_ (error "Cursor can't move up!")]))
+(define (cursor-go-up-until-true cursor predicate?)
+  (cond
+    [(predicate? (cursor-selected-node cursor)) cursor]
+    [(cursor-can-go-up? cursor) (cursor-go-up-until-true (cursor-go-up cursor) predicate?)]
+    [else #f]))
+(define (cursor-go-left current-cursor)
+  (match current-cursor
+    [(cursor selected-node (list fst-left-sibling others ...) parent rights)
+     (cursor fst-left-sibling others parent (cons selected-node rights))]
+    [_ (error "Cursor can't move left!")]))
+(define (cursor-go-right current-cursor)
+  (match current-cursor
+    [(cursor selected-node lefts parent (list fst-right-sibling others ...))
+     (cursor fst-right-sibling (cons selected-node lefts) parent others)]
+    [_ (error "Cursor can't move right!")]))
+(define (cursor-go-to-next-sibling-or-uncle-node cursor doc-is-nested?)
+  (define (is-outside-of-blockquote? cursor) (is-blockquote-leftindent? (cursor-selected-node cursor)))
+  (cond
+    [(cursor-can-go-right? cursor) (cursor-go-right cursor)]
+    [(cursor-can-go-up? cursor)
+     (define parent-cursor (cursor-go-up cursor))
+     (cond
+       ;; If currently parsed doc was `nested`, don't go outside of it - stop parsing here
+       [(and doc-is-nested? (is-outside-of-blockquote? parent-cursor)) #f]
+       [else (cursor-go-to-next-sibling-or-uncle-node parent-cursor doc-is-nested?)])]
+    [else #f]))
+
+
+;; ------------------------------------------
+;; This functions are responsible for finding html nodes that constitute the selected element's documentation
+
+(define (find-doc-beginning-and-take-cursor doc-xexp anchor-name)
+  (define (find-node predicate? cursor)
+    (cond
+      [(predicate? (cursor-selected-node cursor)) cursor]
+      [(cursor-can-go-down? cursor) (find-node predicate? (cursor-go-down cursor))]
+      [(cursor-can-go-right? cursor) (find-node predicate? (cursor-go-right cursor))]
+      [(cursor-can-go-up? cursor)
+       (let loop ([cursor cursor])
+         (cond
+           [(cursor-can-go-right? cursor) (find-node predicate? (cursor-go-right cursor))]
+           [(cursor-can-go-up? cursor) (loop (cursor-go-up cursor))]
+           [else #f]
+           ))]
+      [else #f]))
+  (define (find-doc-beginning cursor)
+    (or
+     (cursor-go-up-until-true cursor
+                              (match-lambda [`(div (@ (class "SIntrapara")) ,_ ...) #t] [_ #f]))
+     ;; Just in case someone for some peculiar reason forgot to include <div class="SIntrapara"> in the documentation
+     (cursor-go-up-until-true cursor
+                              (match-lambda [`(blockquote (@ (class "SVInsetFlow")) ,_ ...) #t] [_ #f]))))
+  (define maybe-cursor (find-node
+                        (λ (x) (equal? x (list 'name anchor-name)))
+                        (make-cursor doc-xexp)))
+  (and maybe-cursor (find-doc-beginning maybe-cursor)))
+
+(define (selected-node-contains-documentation-boundary? cursor doc-is-nested?)
+  (define (find-boundary-node predicate? tree)
+    (cond
+      ;; If the selected docs weren't nested themselves, then we collect nested docs without checking for their boundaries
+      [(and (not doc-is-nested?) (is-blockquote-leftindent? tree)) #f]
+      ;; if there is a list, then we want (probably?) take it as a whole, no matter what boundaries it may have
+      [(tag-name? tree 'ul) #f]
+      [(predicate? tree) tree]
+      [(list? tree) (ormap (λ (x) (find-boundary-node predicate? x)) tree)]
+      [else #f]))
+  (find-boundary-node
+   (match-lambda
+     ;; beginning of docs for the next function, method, struct, or whatever
+     [`(div (@ (class "RBackgroundLabelInner"))
+            (p ,(or "class" "constructor" "interface" "method" "mixin" "parameter" "procedure" "signature" "struct" "syntax" "value"))) #t]
+     ;; end of a doc list ;; e.g. <div class="navsetbottom">
+     [`(@ (class "navsetbottom")) #t]
+     ;; end of a module ;; e.g. <h5 x-source-module="..." ...>
+     [`(@ (x-source-module ,_) ,_ ...) #t]
+     [_ #f])
+   (cursor-selected-node cursor)))
+
+(define (collect-docs cursor doc-is-nested? [is-inside-boundary-node? #f])
+  (cond [(not cursor) '()]
+        ;; we gather doc elements sequentially until we meet documentation for another function
+        [(selected-node-contains-documentation-boundary? cursor doc-is-nested?)
+         ;; hack: the boundary node can be a paragraph <p> that still contains some elements that belong to our doc,
+         ;; so we try to look inside just in case, but only once. That should be enough.
+         (define node (cursor-selected-node cursor))
+         (if (and (not is-inside-boundary-node?) (list? node) (> (length node) 1))
+             (list (car node) ; tag name
+                   (collect-docs (cursor-go-right (cursor-go-down cursor)) doc-is-nested? #t))
+             '())]
+        [else
+         (define next-node-cursor (cursor-go-to-next-sibling-or-uncle-node cursor doc-is-nested?))
+         (cons (cursor-selected-node cursor)
+               (collect-docs next-node-cursor doc-is-nested? is-inside-boundary-node?))]))
+
+
+;; ------------------------------------------
+;; Conversion of HTML into Markdown GFM
+
+(define (tag? mb-tag)
+  (match mb-tag [(list tag-name _ ...) #:when (not (eq? '@ tag-name)) #t] [_ #f])) ; ignore attributes "('@ ...)"
+(define (tag-name? tag name)
+  (match tag [(list (== name)  _ ...) #t] [_ #f]))
+(define (get-tag-attribute tag attr-name)
+  (match tag
+    [(list _ ... (list '@ _ ... (list (== attr-name) attr-value) _ ...) _ ...) attr-value] [_ #f]))
+(define (tag-attribute? tag attr-name attr-value)
+  (equal? attr-value (get-tag-attribute tag attr-name)))
+(define (is-blockquote-leftindent? tree-node)
+  (match tree-node [`(blockquote (@ (class "leftindent") ,_ ...) ,_ ...) #t] [_ #f]))
+
+;; the function tries its best to convert html (in the form of SXML/xexp emitted by 'html-parsing' lib) to Markdown string
+(define (html->markdown html-tag html-file-path)
+  (define code-block-depth 0)
+  (define list-element-depth 0)
+  (define reference-links-table (make-hash))
+
+  (define (recursive-convert tag [parent #f])
+    (define inside-code-block? (> code-block-depth 0))
+    (define inside-list-element? (> list-element-depth 0))
+
+    (define (convert-tag-contents) (string-join (map (λ (child-tag) (recursive-convert child-tag tag)) tag) ""))
+    (define (should-be-in-fenced-code-block? tag) (or (tag-attribute? tag 'class "SCodeFlow") (and (tag-name? tag 'table) (not inside-code-block?))))
+    (define (should-be-emphasized? tag) (ormap (λ (x) (tag-attribute? tag 'class x)) '("RktVar" "RktVal" )))
+    (define (ignore? tag) (ormap (λ (x) (tag-attribute? tag 'class x)) '("refcolumn" "RBackgroundLabelInner")))
+    (define (escape-markdown str)
+      (if inside-code-block? str ; in markdown everything inside code blocks is escaped by default
+          (regexp-replace*
+           #rx"[\n<>]" str
+           (match-lambda
+             ;; Otherwise text like "#<void>" would be rendered just as "#", because Md eats everything that looks like an html tag.
+             ;; Also could be prepended with a slash ('\>') or replaced with an html entity ('&lt;'),
+             ;; but the former doesn't work in Atom's Md parser and both don't look very well if the editor doesn't support Markdown.
+             ["<" "❮"] [">" "❯"]
+             ["\n" " "] [s s]))))
+
+    ;; normally markdown supports html entities but only outside of code blocks
+    (define (convert-if-tag-is-html-entity tag)
+      (match tag ['(& nbsp) " "] ['(& rarr) "->"] ['(& rsquo) "'"] ['(& ldquo) "\""] ['(& rdquo) "\""] ['(& ndash) "-"] [_ #f]))
+
+    (cond
+      [(string? tag) (escape-markdown tag)]
+      [(convert-if-tag-is-html-entity tag) => identity]
+      [(or (not (tag? tag)) (ignore? tag)) ""] ; garbage or just tags that should be ignored for esthetic reasons
+      [(tag-name? tag 'br) "  \n"] ; two spaces with a newline allow line splitting inside emphases (*...*)
+      ;;
+      [(tag-attribute? tag 'class "SHistory") (~a "\n\n*" (convert-tag-contents) "*")] ; changelog paragraph
+      [(tag-name? tag 'tr) (~a "\n" (convert-tag-contents))]
+      [(and (tag-name? tag 'p) (not inside-code-block?)) (~a (if inside-list-element? " " "\n\n") (convert-tag-contents))]
+      [(and (tag-name? tag 'ul)) (~a (convert-tag-contents) "\n\n")]
+      [(and (should-be-emphasized? tag) (not inside-code-block?)) (~a "*" (string-trim (convert-tag-contents)) "*")]
+
+      ;; <blockquote class="leftindent"> usually contains nested docs; we show them indented as list elements for visibility
+      ;; each list level is indented by 4 spaces
+      [(or (tag-name? tag 'li)
+           (and (is-blockquote-leftindent? tag) (not inside-code-block?)
+                (match parent [`(,_ (@ ,_) (blockquote ,_ ...)) #f] [_ #t]))) ; don't indent blockquote if it's only one
+       (set! list-element-depth (add1 list-element-depth))
+       (define contents (string-trim (convert-tag-contents)))
+       (set! list-element-depth (sub1 list-element-depth))
+       (if (non-empty-string? contents)
+           (~a "\n-   "
+               (string-replace contents "\n" "\n    ") ; indent each line
+               (if (tag-name? tag 'li) "" "\n"))
+           "")]
+
+      [(should-be-in-fenced-code-block? tag) ; mainly actual code blocks but also includes <table>s
+       (set! code-block-depth (add1 code-block-depth))
+       ;; get rid of unnecessary whitespaces
+       (define codeblock-contents (string-trim (string-replace (convert-tag-contents) "\n\n" "\n")))
+       (set! code-block-depth (sub1 code-block-depth))
+       (~a "\n\n```\n" codeblock-contents "\n```\n\n")]
+
+      [(or (and (tag-name? tag 'a) (not inside-code-block?)) (tag-name? tag 'img)) ; links (<a href=...>) or images (<img src=...>)
+       ;; we replace relative URLs with absolute ones referencing online documentation (because offline links don't work in VSCode)
+       ;; same for images with 'src' attribute
+       (define is-img? (tag-name? tag 'img))
+       (define mb-link-attr (get-tag-attribute tag (if is-img? 'src 'href)))
+       (define maybe-url (if mb-link-attr
+                             (make-proper-url-for-online-documentation mb-link-attr html-file-path) #f))
+       (cond
+         [(not maybe-url) (convert-tag-contents)] ; empty href -> no link
+         ;; Image: ![ImageName](URL)
+         [is-img?
+          (define img (~a "![" (or (get-tag-attribute tag 'alt) "HereWasImage") "](" maybe-url ")"))
+          (if inside-code-block? (~a "\n```\n" img "\n```\n") img)] ; temporarily close a code block as images can't be shown inside them
+         ;; Reference link: [LinkName] ... [LinkName]: URL
+         [else
+          (define contents (convert-tag-contents))
+          (hash-set! reference-links-table contents maybe-url)
+          (~a "[" contents "]")])]
+
+      [else (convert-tag-contents)]))
+
+  ;; some cosmetic additions: combine consecutive emphasized regions and newlines for readability (in case the text editor doesn't support markdown)
+  (define generated-markdown (string-replace (recursive-convert html-tag) "**" ""))
+  (define prettified-markdown (string-trim (string-replace generated-markdown #px"\n{3,}" "\n\n")))
+  (define reference-links (hash-map reference-links-table (λ (link-name link-url) (~a "[" link-name "]: " link-url))))
+  (~a prettified-markdown "\n\n" (string-join reference-links "\n")))
+
+
+;; ------------------------------------------
+;; ------------------------------------------
+
+;; `docs-uri` example: file:///C:/Program%20Files/Racket/doc/reference/define.html#(form._((lib._racket%2Fprivate%2Fbase..rkt)._define))
+(define (extract-documentation docs-uri include-signature?)
+  (define url (string->url docs-uri))
+  (define doc-element-name (url-fragment url))
+  (define html-file-path (string-join (map path/param-path (url-path url)) "/")) ; used for resolving URLs in the documentation
+
+  (define maybe-html-file
+    (with-handlers ([exn:fail:filesystem? (λ _ #f)])
+      (open-input-file (url->path url))))
+
+  (cond [(and maybe-html-file doc-element-name)
+         (define doc-xexp (html->xexp maybe-html-file)) ; parse the html file with `html-parsing` lib
+         (close-input-port maybe-html-file)
+
+         ;; So how that html docs `extracting` stuff works.
+         ;; At first, we find the first element (i.e. HTML node) of the documentation for the function that we've selected.
+         ;; Almost always (99.99%) it's `<div class=SIntrapara>` that contains `<a name=`doc-element-name`>` inside.
+         ;; And it also has the function signature.
+         ;; After that, we start to collect all consecutive elements until we meet a boundary node.
+         ;; The boundary node is an HTML tag that begins documentation for some other element (next function, method, etc).
+         (define cursor-at-signature (find-doc-beginning-and-take-cursor doc-xexp doc-element-name))
+         (cond [cursor-at-signature
+                ;; Docs can be sort of nested in each other.
+                ;; If `div` with signature is initially located inside <blockquote>, the documentation is counted as `nested`.
+                ;; For example: https://docs.racket-lang.org/reference/require.html#(form._((lib._racket%2Fprivate%2Fbase..rkt)._require))
+                ;; There, `only-in` is nested in `require`.
+                ;; The distinction is important for detection of boundary nodes.
+                ;; If we parse some nested doc, we want to stop before the next one.
+                ;; But if the selected docs aren't nested, we want to also get every nested doc inside (if any), ignoring their boundary nodes.
+                (define doc-is-nested? (cursor-go-up-until-true cursor-at-signature is-blockquote-leftindent?))
+
+                (define cursor-after-signature (cursor-go-to-next-sibling-or-uncle-node cursor-at-signature doc-is-nested?))
+                (define doc-without-signature-html (collect-docs cursor-after-signature doc-is-nested?))
+                (define doc-without-signature-markdown (html->markdown doc-without-signature-html html-file-path))
+
+                (~a (if include-signature?
+                        (~a (html->markdown (cursor-selected-node cursor-at-signature) html-file-path) "\n---\n") "")
+                    doc-without-signature-markdown)]
+               [else #f])]
+        [else #f]))
+
+(define weak-cache (make-weak-hash))
+(define (extract-documentation-for-selected-element docs-uri #:include-signature? include-signature?)
+  (hash-ref! weak-cache docs-uri (thunk (extract-documentation docs-uri include-signature?))))
+
+
+(provide extract-documentation-for-selected-element)

--- a/info.rkt
+++ b/info.rkt
@@ -8,6 +8,7 @@
                "syntax-color-lib"
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
+               "html-parsing" ;; for parsing documentation text
                ))
 (define build-deps '("chk"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")


### PR DESCRIPTION
I think this is an important feature for any programming tool to have.
Maybe there is a less insane approach to get that documentation text (though if there was, probably it would be implemented already), but I just parse it with `html-parsing` lib, extract relevant pieces of the documentaion for the selected element, convert this pieces of html into a Markdown string, and put that Markdown in `hover` response.
Demonstration:

https://user-images.githubusercontent.com/8329446/147808687-81653997-cd6f-4bea-9e6a-38c1c5537003.mp4

Looks surprisingly decent.

I've tried to make generated Markdown as human-readable as possible (in general, Markdown *can* be extremely human unreadable), so even if the used text editor doesn't support Markdown (for some incomprehensible reason), it still should be fairly usable. [Here is an example of generated Markdown] and how it would look in VS Code

And I've also fixed a couple of small bugs.
1) Links that contain a closing paren (`)`) aren't rendered correctly in Atom (because Atom's Md parser treats it as a link 'delimiter'). Now the links are encoded properly.
	Screenshot with the bug:
![bug1](https://user-images.githubusercontent.com/8329446/147808681-3e5f4b23-c858-4c24-a03e-4cf970bed3c9.png)

2) Currently links aren't constructed correctly if the documentation is not in a usual place (by usual I mean something like `C:/Program Files/Racket/doc/...`). For example, on Ubuntu, when Racket is installed from the default packet manager (i.e. `apt install racket`), docs are located in `/usr/share/doc/racket/...`.  The problem here is that `racket` part goes after `doc`. The current approach was to simple split path by `/doc/` and I've just changed it to simply splittling by `/doc/(racket/)?`, which is enough for this particular case.
	That kinda fixes #72.
	Screenshot with the bug: 
![bug2](https://user-images.githubusercontent.com/8329446/147808677-06e26d63-d168-425d-8dad-88e845fd74b4.png)

3) I really don't know why, but sometimes URLs come without url-tags (like `#(def._((quote._~23~25kernel)._hasheq))`), but 'raw' tags (i.e. `'(def ((quote #%kernel) hasheq))`) are still there. I've solved it by additionaly converting this 'raw' tags into url-tags when original url-tags are not present.
	Screenshot with the bug:
![bug3](https://user-images.githubusercontent.com/8329446/147808674-92b61ab2-1558-4775-bce8-e457b44cc179.png)

I hope I did everything right, never programmed anything significant in lisp.
	
	
[Here is an example of generated Markdown]: https://marked.js.org/demo/?text=Opens%20the%20file%20specified%20by%20*path*%20for%20input.%20The%20*mode-flag*%20argument%20specifies%20how%20the%20file%27s%20bytes%20are%20translated%20on%20input%3A%0A-%20%20%20*%27binary*%20%E2%80%94%20bytes%20are%20returned%20from%20the%20port%20exactly%20as%20they%20are%20read%20from%20the%20file.%0A-%20%20%20*%27text*%20%E2%80%94%20return%20and%20linefeed%20bytes%20(10%20and%2013)%20as%20read%20from%20the%20file%20are%20filtered%20by%20the%20port%20in%20a%20platform%20specific%20manner%3A%0A%20%20%20%20-%20%20%20Unix%20and%20Mac%20OS%3A%20no%20filtering%20occurs.%0A%20%20%20%20-%20%20%20Windows%3A%20a%20return-linefeed%20combination%20from%20a%20file%20is%20returned%20by%20the%20port%20as%20a%20single%20linefeed%3B%20no%20filtering%20occurs%20for%20return%20bytes%20that%20are%20not%20followed%20by%20a%20linefeed%2C%20or%20for%20a%20linefeed%20that%20is%20not%20preceded%20by%20a%20return.%0A%0AOn%20Windows%2C%20*%27text*%20mode%20works%20only%20with%20regular%20files%3B%20attempting%20to%20use%20*%27text*%20with%20other%20kinds%20of%20files%20triggers%20an%20%5Bexn%3Afail%3Afilesystem%5D%20exception.%0A%0AOtherwise%2C%20the%20file%20specified%20by%20*path*%20need%20not%20be%20a%20regular%20file.%20It%20might%20be%20a%20device%20that%20is%20connected%20through%20the%20filesystem%2C%20such%20as%20%22aux%22%20on%20Windows%20or%20%22%2Fdev%2Fnull%22%20on%20Unix.%20In%20all%20cases%2C%20the%20port%20is%20buffered%20by%20default.%0A%0AThe%20port%20produced%20by%20%5Bopen-input-file%5D%20should%20be%20explicitly%20closed%2C%20either%20though%20%5Bclose-input-port%5D%20or%20indirectly%20via%20%5Bcustodian-shutdown-all%5D%2C%20to%20release%20the%20OS-level%20file%20handle.%20The%20input%20port%20will%20not%20be%20closed%20automatically%20if%20it%20is%20otherwise%20available%20for%20garbage%20collection%20(see%20%5BGarbage%20Collection%5D)%3B%20a%20%5Bwill%5D%20could%20be%20associated%20with%20an%20input%20port%20to%20close%20it%20more%20automatically%20(see%20%5BWills%20and%20Executors%5D).%0A%0AA%20%5Bpath%5D%20value%20that%20is%20the%20%5Bcleanse%5Dd%20version%20of%20*path*%20is%20used%20as%20the%20name%20of%20the%20opened%20port.%0A%0AIf%20opening%20the%20file%20fails%20due%20to%20an%20error%20in%20the%20filesystem%2C%20then%20%5Bexn%3Afail%3Afilesystem%3Aerrno%5D%20exception%20is%20raised%E2%80%94as%20long%20as%20*for-module%3F*%20is%20*%23f*%2C%20%5Bcurrent-module-path-for-load%5D%20has%20a%20non-*%23f*%20value%2C%20or%20the%20filesystem%20error%20is%20not%20recognized%20as%20a%20file-not-found%20error.%20Otherwise%2C%20when%20*for-module%3F*%20is%20true%2C%20%5Bcurrent-module-path-for-load%5D%20has%20a%20non-*%23f*%20value%2C%20and%20the%20filesystem%20error%20is%20recognized%20as%20a%20file-not-found%20error%2C%20then%20the%20raised%20exception%20is%20either%20%5Bexn%3Afail%3Asyntax%3Amissing-module%5D%20(if%20the%20value%20of%20%5Bcurrent-module-path-for-load%5D%20is%20a%20%5Bsyntax%20object%5D)%20or%20%5Bexn%3Afail%3Afilesystem%3Amissing-module%5D%20(otherwise).%0A%0A*Changed%20in%20version%206.0.1.6%20of%20package%20base%3A%20Added%20%23%3Afor-module%3F.*%0A%0AExamples%3A%0A%0A%60%60%60%0A%3E%20(with-output-to-file%20some-file%0A%20%20%20%20(lambda%20()%20(printf%20%22hello%20world%22)))%0A%3E%20(define%20in%20(open-input-file%20some-file))%0A%3E%20(read-string%2011%20in)%0A%22hello%20world%22%0A%3E%20(close-input-port%20in)%0A%60%60%60%0A%0A%5BGarbage%20Collection%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Feval-model.html%23%2528part._gc-model%2529%0A%5Bpath%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fpathutils.html%23%2528tech._path%2529%0A%5Bexn%3Afail%3Afilesystem%3Aerrno%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fexns.html%23%2528def._%2528%2528lib._racket%252Fprivate%252Fbase..rkt%2529._exn%257E3afail%257E3afilesystem%257E3aerrno%2529%2529%0A%5Bexn%3Afail%3Afilesystem%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fexns.html%23%2528def._%2528%2528lib._racket%252Fprivate%252Fbase..rkt%2529._exn%257E3afail%257E3afilesystem%2529%2529%0A%5Bopen-input-file%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Ffile-ports.html%23%2528def._%2528%2528lib._racket%252Fprivate%252Fbase..rkt%2529._open-input-file%2529%2529%0A%5Bclose-input-port%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fport-ops.html%23%2528def._%2528%2528quote._%257E23%257E25kernel%2529._close-input-port%2529%2529%0A%5Bexn%3Afail%3Afilesystem%3Amissing-module%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fexns.html%23%2528def._%2528%2528lib._racket%252Fprivate%252Fbase..rkt%2529._exn%257E3afail%257E3afilesystem%257E3amissing-module%2529%2529%0A%5Bsyntax%20object%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fsyntax-model.html%23%2528tech._syntax._object%2529%0A%5Bexn%3Afail%3Asyntax%3Amissing-module%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fexns.html%23%2528def._%2528%2528lib._racket%252Fprivate%252Fbase..rkt%2529._exn%257E3afail%257E3asyntax%257E3amissing-module%2529%2529%0A%5Bcustodian-shutdown-all%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fcustodians.html%23%2528def._%2528%2528quote._%257E23%257E25kernel%2529._custodian-shutdown-all%2529%2529%0A%5BWills%20and%20Executors%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fwillexecutor.html%0A%5Bcleanse%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fpathutils.html%23%2528tech._cleanse%2529%0A%5Bcurrent-module-path-for-load%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2FModule_Names_and_Loading.html%23%2528def._%2528%2528quote._%257E23%257E25kernel%2529._current-module-path-for-load%2529%2529%0A%5Bwill%5D%3A%20https%3A%2F%2Fdocs.racket-lang.org%2Freference%2Fwillexecutor.html%23%2528tech._will%2529&options=%7B%0A%20%22baseUrl%22%3A%20null%2C%0A%20%22breaks%22%3A%20true%2C%0A%20%22extensions%22%3A%20null%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22headerIds%22%3A%20false%2C%0A%20%22headerPrefix%22%3A%20%22%22%2C%0A%20%22highlight%22%3A%20null%2C%0A%20%22langPrefix%22%3A%20%22language-%22%2C%0A%20%22mangle%22%3A%20false%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22sanitize%22%3A%20true%2C%0A%20%22sanitizer%22%3A%20null%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22smartLists%22%3A%20true%2C%0A%20%22smartypants%22%3A%20true%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%2C%0A%20%22xhtml%22%3A%20true%0A%7D&version=4.0.8
	