### PR TITLE
wrap identifier with `|` to get valid renaming

### DIFF
--- a/text-document.rkt
+++ b/text-document.rkt
@@ -342,17 +342,15 @@
      (define result
        (match decl
          [(Decl req? id left right)
-          (define new-text
-            (if (string-contains? new-name " ")
-                (string-append "|" new-name "|")
-                new-name))
           (cond [req? (json-null)]
                 [else
                  (define ranges (cons (start/end->Range doc-text left right) (get-bindings uri decl)))
                  (hasheq 'changes
                          (hasheq (string->symbol uri)
                                  (for/list ([range (in-list ranges)])
-                                   (TextEdit #:range range #:newText new-text))))])]
+                                   (TextEdit #:range range
+                                             #:newText
+                                             (string-trim (format "~v" (string->symbol new-name)) "'")))))])]
          [#f (json-null)]))
      (success-response id result)]
     [_

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -342,13 +342,17 @@
      (define result
        (match decl
          [(Decl req? id left right)
+          (define new-text
+            (if (string-contains? new-name " ")
+                (string-append "|" new-name "|")
+                new-name))
           (cond [req? (json-null)]
                 [else
                  (define ranges (cons (start/end->Range doc-text left right) (get-bindings uri decl)))
                  (hasheq 'changes
                          (hasheq (string->symbol uri)
                                  (for/list ([range (in-list ranges)])
-                                   (TextEdit #:range range #:newText new-name))))])]
+                                   (TextEdit #:range range #:newText new-text))))])]
          [#f (json-null)]))
      (success-response id result)]
     [_

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -350,7 +350,7 @@
                                  (for/list ([range (in-list ranges)])
                                    (TextEdit #:range range
                                              #:newText
-                                             (string-trim (format "~v" (string->symbol new-name)) "'")))))])]
+                                             (format "~s" (string->symbol new-name))))))])]
          [#f (json-null)]))
      (success-response id result)]
     [_


### PR DESCRIPTION
```racket
(define foo 1)
foo
```

If rename `foo` to `foo bar`, the new text should be `|foo bar|`, for convenience.