### PR TITLE
rename require module path when that module gets file renamed

### DIFF
--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -20,6 +20,7 @@
     (define docs (make-interval-map))
     (define completions (list))
     (define requires (make-interval-map))
+    (define requires-occurs (make-hash))
     ;; decl -> (set pos ...)
     (define sym-decls (make-interval-map))
     ;; pos -> decl
@@ -30,7 +31,8 @@
       (set! docs (make-interval-map))
       (set! sym-decls (make-interval-map))
       (set! sym-bindings (make-interval-map))
-      (set! requires (make-interval-map)))
+      (set! requires (make-interval-map))
+      (set! requires-occurs (make-hash)))
     (define/public (expand start end)
       (define inc (- end start))
       (move-interior-intervals sym-decls (- start 1) inc)
@@ -66,6 +68,7 @@
     (define/public (get-completions) completions)
     (define/public (set-completions new-completions) (set! completions new-completions))
     (define/public (get-requires) requires)
+    (define/public (get-requires-occurs) requires-occurs)
     (define/public (get-sym-decls) sym-decls)
     (define/public (get-sym-bindings) sym-bindings)
     ;; Overrides
@@ -74,6 +77,7 @@
            src))
     ;; Track requires
     (define/override (syncheck:add-require-open-menu text start finish file)
+      (hash-set! requires-occurs file (cons start finish))
       (interval-map-set! requires start finish file))
     ;; Mouse-over status
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)

--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -30,6 +30,10 @@
   [start any/c]
   [end any/c])
 
+(define-json-expander TextEdit
+  [range any/c]
+  [newText string?])
+
 (define (abs-pos->Pos t pos)
   (define line (send t position-paragraph pos))
   (define line-begin (send t paragraph-start-position line))

--- a/methods.rkt
+++ b/methods.rkt
@@ -6,8 +6,8 @@
          "error-codes.rkt"
          "msg-io.rkt"
          "responses.rkt"
-         (prefix-in workspace/ "workspace.rkt")
-         (prefix-in text-document/ "text-document.rkt"))
+         (prefix-in workspace/ "methods/workspace.rkt")
+         (prefix-in text-document/ "methods/text-document.rkt"))
 
 ;; TextDocumentSynKind enumeration
 (define TextDocSync-None 0)

--- a/methods.rkt
+++ b/methods.rkt
@@ -6,6 +6,7 @@
          "error-codes.rkt"
          "msg-io.rkt"
          "responses.rkt"
+         "store/workspace.rkt"
          (prefix-in workspace/ "methods/workspace.rkt")
          (prefix-in text-document/ "methods/text-document.rkt"))
 
@@ -112,7 +113,10 @@
 (define (initialize id params)
   (match params
     [(hash-table ['processId (? (or/c number? (json-null)) process-id)]
+                 ['rootUri (? (or/c string? (json-null)) uri)]
                  ['capabilities (? jsexpr? capabilities)])
+     (unless (eq? uri 'null)
+       (set-box! rootUri uri))
      (define sync-options
        (hasheq 'openClose #t
                'change TextDocSync-Incremental

--- a/methods.rkt
+++ b/methods.rkt
@@ -6,6 +6,7 @@
          "error-codes.rkt"
          "msg-io.rkt"
          "responses.rkt"
+         (prefix-in workspace/ "workspace.rkt")
          (prefix-in text-document/ "text-document.rkt"))
 
 ;; TextDocumentSynKind enumeration
@@ -59,6 +60,8 @@
        (initialize id params)]
       ["shutdown"
        (shutdown id)]
+      ["workspace/willRenameFiles"
+       (workspace/willRenameFiles id params)]
       ["textDocument/hover"
        (text-document/hover id params)]
       ["textDocument/completion"
@@ -115,6 +118,14 @@
                'change TextDocSync-Incremental
                'willSave #f
                'willSaveWaitUntil #f))
+     (define workspace-options
+       (hasheq
+        ; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFoldersServerCapabilities
+        'workspaceFolders (hasheq 'supported #t
+                                  'changeNotifications #t)
+        ; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileOperationRegistrationOptions
+        ;'fileOperations (hasheq 'willRename (hasheq 'filters (list )))
+        ))
      (define renameProvider
        (match capabilities
          [(hash-table ['textDocument
@@ -124,6 +135,7 @@
          [_ #t]))
      (define server-capabilities
        (hasheq 'textDocumentSync sync-options
+               'workspace workspace-options
                'hoverProvider #t
                'definitionProvider #t
                'referencesProvider #t

--- a/methods/text-document.rkt
+++ b/methods/text-document.rkt
@@ -7,17 +7,17 @@
          syntax-color/racket-lexer
          drracket/check-syntax
          syntax/modread
-         "check-syntax.rkt"
-         "error-codes.rkt"
-         "interfaces.rkt"
-         "json-util.rkt"
-         "path-util.rkt"
-         "responses.rkt"
-         "symbol-kinds.rkt"
-         "docs-helpers.rkt"
-         "doc-trace.rkt"
-         "queue-only-latest.rkt"
-         "documentation-parser.rkt")
+         "../check-syntax.rkt"
+         "../error-codes.rkt"
+         "../interfaces.rkt"
+         "../json-util.rkt"
+         "../path-util.rkt"
+         "../responses.rkt"
+         "../symbol-kinds.rkt"
+         "../docs-helpers.rkt"
+         "../doc-trace.rkt"
+         "../queue-only-latest.rkt"
+         "../documentation-parser.rkt")
 
 ;;
 ;; Match Expanders

--- a/methods/workspace.rkt
+++ b/methods/workspace.rkt
@@ -1,8 +1,12 @@
 #lang racket/base
 (require json
          racket/gui
+         "../store/docs.rkt"
+         "../store/workspace.rkt"
          "../error-codes.rkt"
          "../json-util.rkt"
+         "../path-util.rkt"
+         "../interfaces.rkt"
          "../responses.rkt")
 
 ; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileRename
@@ -15,15 +19,44 @@
 ;;;;;;;;;;;;
 
 ;; Will Rename Files request
+;;
 ;; spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
+;;
 ;; Response:
 ;;   result: WorkspaceEdit | null
 ;;   error: code and message set in case an exception happens during the workspace/willRenameFiles request.
 (define (willRenameFiles id params)
   (match params
-    [(hash-table ['files files])
-     ; TODO: update all modules that imports the renamed file
-     (success-response id null)]
+    ; export interface RenameFilesParams {
+    ; 	/**
+    ; 	 * An array of all files/folders renamed in this operation. When a folder
+    ; 	 * is renamed, only the folder will be included, and not its children.
+    ; 	 */
+    ; 	files: FileRename[];
+    ; }
+    [(hash-table ['files renamed-files])
+     (define files-in-workspace (find-files (λ (p) (path-has-extension? p #".rkt"))
+                                            (uri->path (unbox rootUri))))
+     (define changes (make-hasheq))
+     (for ([file-path files-in-workspace])
+       (match-define (doc doc-text doc-trace) (get-doc (path->uri file-path)))
+       (for ([renamed-file renamed-files])
+         (match-define (hash-table ['oldUri oldUri] ['newUri newUri]) renamed-file)
+         (define range-to-update (hash-ref (send doc-trace get-requires-occurs)
+                                           (path->string (find-relative-path (path-only file-path) (uri->path oldUri)))
+                                           #f))
+         (when range-to-update
+           (match-define (cons start end) range-to-update)
+           (hash-set! changes
+                      (path->uri file-path)
+                      ; TextEdit[]
+                      (list (TextEdit #:range (start/end->Range doc-text start end)
+                                      #:newText (string-append "\""
+                                                               (path->string (find-relative-path (path-only file-path) (uri->path newUri)))
+                                                               "\"")))))))
+     (success-response id (hasheq
+                           ; { [uri: DocumentUri]: TextEdit[]; }
+                           'changes changes))]
     [_ (error-response id INVALID-PARAMS "workspace/willRenameFiles failed")]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/methods/workspace.rkt
+++ b/methods/workspace.rkt
@@ -1,9 +1,9 @@
 #lang racket/base
 (require json
          racket/gui
-         "error-codes.rkt"
-         "json-util.rkt"
-         "responses.rkt")
+         "../error-codes.rkt"
+         "../json-util.rkt"
+         "../responses.rkt")
 
 ; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileRename
 (define-json-expander FileRename

--- a/store/docs.rkt
+++ b/store/docs.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+(provide get-doc
+         add-doc
+         remove-doc)
+(require racket/class
+         framework
+         "../path-util.rkt"
+         "../check-syntax.rkt"
+         "../interfaces.rkt")
+
+(define open-docs (make-hasheq))
+
+(define (get-doc uri) (hash-ref open-docs (string->symbol uri)))
+
+(define (add-doc uri)
+  (define path (uri->path uri))
+  (define doc-text (new racket:text%))
+  (send doc-text load-file path)
+  (define trace (check-syntax path doc-text #f))
+  (hash-set! open-docs (string->symbol uri) (doc doc-text trace)))
+
+(define (remove-doc uri) (hash-remove! open-docs (string->symbol uri)))

--- a/store/workspace.rkt
+++ b/store/workspace.rkt
@@ -1,0 +1,4 @@
+#lang racket/base
+(provide rootUri)
+
+(define rootUri (box #f))

--- a/workspace.rkt
+++ b/workspace.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+(require json
+         racket/gui
+         "error-codes.rkt"
+         "json-util.rkt"
+         "responses.rkt")
+
+; https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileRename
+(define-json-expander FileRename
+  [oldUri string?]
+  [newUri string?])
+
+;;
+;; Methods
+;;;;;;;;;;;;
+
+;; Will Rename Files request
+;; spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
+;; Response:
+;;   result: WorkspaceEdit | null
+;;   error: code and message set in case an exception happens during the workspace/willRenameFiles request.
+(define (willRenameFiles id params)
+  (match params
+    [(hash-table ['files files])
+     ; TODO: update all modules that imports the renamed file
+     (success-response id null)]
+    [_ (error-response id INVALID-PARAMS "workspace/willRenameFiles failed")]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(provide
+ (contract-out
+  [willRenameFiles (exact-nonnegative-integer? jsexpr? . -> . jsexpr?)]))


### PR DESCRIPTION
NOTE: still in progress

This functionality will be handled in the method `workspace/willRenameFiles`. The target is to do import updation on file rename.

Example
- `a.rkt` has `(require "b.rkt")`
- user rename `b.rkt` to `c.rkt`
- `a.rkt` should get modification that `(require "b.rkt")` to `(require "c.rkt")`

Related with #74 