### PR TITLE
[method] `textDocument/inlayHint`

### DIFF
--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -20,6 +20,7 @@
     (define docs (make-interval-map))
     (define completions (list))
     (define requires (make-interval-map))
+    (define definitions (make-hash))
     ;; decl -> (set pos ...)
     (define sym-decls (make-interval-map))
     ;; pos -> decl
@@ -30,7 +31,8 @@
       (set! docs (make-interval-map))
       (set! sym-decls (make-interval-map))
       (set! sym-bindings (make-interval-map))
-      (set! requires (make-interval-map)))
+      (set! requires (make-interval-map))
+      (set! definitions (make-hash)))
     (define/public (expand start end)
       (define inc (- end start))
       (move-interior-intervals sym-decls (- start 1) inc)
@@ -68,10 +70,14 @@
     (define/public (get-requires) requires)
     (define/public (get-sym-decls) sym-decls)
     (define/public (get-sym-bindings) sym-bindings)
+    (define/public (get-definitions) definitions)
     ;; Overrides
     (define/override (syncheck:find-source-object stx)
       (and (equal? src (syntax-source stx))
            src))
+    ;; Definitions
+    (define/override (syncheck:add-definition-target src-obj start end id mods)
+      (hash-set! definitions id (Decl src id start end)))
     ;; Track requires
     (define/override (syncheck:add-require-open-menu text start finish file)
       (interval-map-set! requires start finish file))

--- a/methods.rkt
+++ b/methods.rkt
@@ -73,6 +73,8 @@
        (text-document/references id params)]
       ["textDocument/documentSymbol"
        (text-document/document-symbol id params)]
+      ["textDocument/inlayHint"
+       (text-document/inlay-hint id params)]
       ["textDocument/rename"
        (text-document/rename id params)]
       ["textDocument/prepareRename"
@@ -129,6 +131,7 @@
                'referencesProvider #t
                'completionProvider (hasheq 'triggerCharacters (list "("))
                'signatureHelpProvider (hasheq 'triggerCharacters (list " " ")" "]"))
+               'inlayHintProvider #t
                'renameProvider renameProvider
                'documentHighlightProvider #t
                'documentSymbolProvider #t

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -442,13 +442,7 @@
      (error-response id INVALID-PARAMS "document-symbol: uri is not a path")]
     [(hash-table ['textDocument (DocIdentifier #:uri uri)]
                  ['range (Range  #:start start #:end end)])
-     (match-define (doc doc-text doc-trace)
-       (hash-ref open-docs (string->symbol uri)))
-     (success-response id (map (lambda (decl)
-                                 (InlayHint #:position (abs-pos->Pos doc-text (Decl-left decl))
-                                            #:label (format "defined in ~a" (Decl-require? decl))))
-                               (dict-values (send doc-trace get-definitions))))
-     ]
+     (success-response id '())]
     [_ (error-response id INVALID-PARAMS "textDocument/inlayHint failed")]))
 
 ;; Full document formatting request


### PR DESCRIPTION
The current implementation will show "defined in file-xxx" for every definition. This is not quite helpful of course, to get more useful functionality, `check-syntax` should be able to collect the form of procedure like `(hash-ref hash key)`.

Then collector can collect this information and provide hints like `(hash-ref hash (make-hash) key 'a)`, notice that `hash` and `key` previous shows are inlay hints.

Below is the current situation:
<img width="970" alt="圖片" src="https://user-images.githubusercontent.com/22004511/198119211-a003f631-3412-4c21-b6ac-11064698c557.png">
