### PR TITLE
provides `Diagnostic` for unused variable

### DIFF
--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -87,6 +87,13 @@
       ;; XXX This might not exactly match the behavior in DrRacket.
       (when (= start finish)
         (set! finish (add1 finish)))
+      (when (string=? "no bound occurrences" text)
+        (define diag (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text start)
+                                                #:end   (abs-pos->Pos doc-text finish))
+                                 #:severity Diag-Information
+                                 #:source src-obj
+                                 #:message "unused variable"))
+        (set-add! warn-diags diag))
       (interval-map-set! hovers start finish text))
     ;; Docs
     (define/override (syncheck:add-docs-menu text start finish id label path def-tag url-tag)

--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -106,9 +106,7 @@
                   (hasheq (string->symbol (path->uri src-obj))
                           (TextEdit #:range (Range #:start (abs-pos->Pos doc-text start)
                                                    #:end   (abs-pos->Pos doc-text finish))
-                                    #:newText "_")))
-          #:data (Range #:start (abs-pos->Pos doc-text start)
-                        #:end   (abs-pos->Pos doc-text finish))))
+                                    #:newText "_")))))
 
         (set-add! warn-diags diag)))
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)

--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -16,9 +16,7 @@
   [kind string?]
   [diagnostics any/c]
   [isPreferred boolean?]
-  [edit any/c]
-  ;; here, we put edit range
-  [data any/c])
+  [edit any/c])
 
 (define-json-expander Diagnostic
   [range any/c]

--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -11,6 +11,14 @@
 (define-json-expander TextEdit
   [range any/c]
   [newText string?])
+(define-json-expander CodeAction
+  [title string?]
+  [kind string?]
+  [diagnostics any/c]
+  [isPreferred boolean?]
+  [edit any/c]
+  ;; here, we put edit range
+  [data any/c])
 
 (define-json-expander Diagnostic
   [range any/c]

--- a/interfaces.rkt
+++ b/interfaces.rkt
@@ -6,6 +6,12 @@
          racket/match
          "json-util.rkt")
 
+(define-json-expander WorkspaceEdit
+  [changes any/c])
+(define-json-expander TextEdit
+  [range any/c]
+  [newText string?])
+
 (define-json-expander Diagnostic
   [range any/c]
   [severity (or/c 1 2 3 4)]

--- a/methods.rkt
+++ b/methods.rkt
@@ -61,6 +61,8 @@
        (shutdown id)]
       ["textDocument/hover"
        (text-document/hover id params)]
+      ["textDocument/codeAction"
+       (text-document/code-action id params)]
       ["textDocument/completion"
        (text-document/completion id params)]
       ["textDocument/signatureHelp"
@@ -127,6 +129,7 @@
      (define server-capabilities
        (hasheq 'textDocumentSync sync-options
                'hoverProvider #t
+               'codeActionProvider #t
                'definitionProvider #t
                'referencesProvider #t
                'completionProvider (hasheq 'triggerCharacters (list "("))
@@ -155,3 +158,4 @@
  (contract-out
   [process-message
    (jsexpr? . -> . void?)]))
+

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -52,10 +52,6 @@
   [kind exact-positive-integer?]
   [location any/c])
 
-(define-json-expander TextEdit
-  [range any/c]
-  [newText string?])
-
 (define-json-expander InlayHint
   ; must a position `Pos`, defined in interfaces.rkt
   [position any/c]
@@ -350,10 +346,11 @@
           (cond [req? (json-null)]
                 [else
                  (define ranges (cons (start/end->Range doc-text left right) (get-bindings uri decl)))
-                 (hasheq 'changes
-                         (hasheq (string->symbol uri)
-                                 (for/list ([range (in-list ranges)])
-                                   (TextEdit #:range range #:newText new-name))))])]
+                 (WorkspaceEdit
+                  #:changes
+                  (hasheq (string->symbol uri)
+                          (for/list ([range (in-list ranges)])
+                            (TextEdit #:range range #:newText new-name))))])]
          [#f (json-null)]))
      (success-response id result)]
     [_


### PR DESCRIPTION
This PR creates three things for "unused variable"

1. diagnostic hints for it
2. ignore variables that prefix with `_`, e.g. `_xxx`
3. quick fix that fixes it with prepending `_` to variable

Notice that the quick fix needs the client's ability

@jeapostrophe do you know who can update magic-racket to enable `textDocument/codeAction`?

### demo diagnostic
<img width="1050" alt="圖片" src="https://user-images.githubusercontent.com/22004511/203170037-ad9dbd39-d2dc-4532-9269-a189bdf7dffb.png">

### demo code action
<img width="618" alt="圖片" src="https://user-images.githubusercontent.com/22004511/203700340-ba534b70-8359-42e0-8f16-7030a0dc5bb7.png">
