### PR TITLE
fix extra empty lines (#82) in formatting

### DIFF
--- a/text-document.rkt
+++ b/text-document.rkt
@@ -508,7 +508,7 @@
                (when (and (char=? #\" (send mut-doc-text get-character i))
                           (not (char=? #\\ (send mut-doc-text get-character (sub1 i)))))
                  (set! skip-this-line? (not skip-this-line?))))
-             (if (> line end-line)
+             (if (>= line end-line)
                  null
                  (append (filter-map
                           identity


### PR DESCRIPTION
For some reason, `end-line` is actually the number of lines of the file (0 based).

For example, the file have 3 lines. We finally have this [`TextEdit`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit) object in the response:

```json
{
  "newText": "",
  "range": {
    "start": {
      "character": 0,
      "line": 3
    },
    "end": {
      "character": 0,
      "line": 3
    }
  }
}
```

According to the protocol, this range is empty. It will depend on how the client process it.
I think it's a neovim bug. Anyway, we can avoid this useless response in our server.