### PR TITLE
fix range/formatting

### DIFF
--- a/text-document.rkt
+++ b/text-document.rkt
@@ -491,7 +491,7 @@
        (hash-ref open-docs (string->symbol uri)))
      (define indenter (send doc-trace get-indenter))
      (define start-pos (Pos->abs-pos doc-text start))
-     (define end-pos (Pos->abs-pos doc-text end))
+     (define end-pos (max 0 (sub1 (Pos->abs-pos doc-text end))))
      (define start-line (send doc-text position-paragraph start-pos))
      (define end-line (send doc-text position-paragraph end-pos))
      (define mut-doc-text
@@ -508,7 +508,7 @@
                (when (and (char=? #\" (send mut-doc-text get-character i))
                           (not (char=? #\\ (send mut-doc-text get-character (sub1 i)))))
                  (set! skip-this-line? (not skip-this-line?))))
-             (if (>= line end-line)
+             (if (> line end-line)
                  null
                  (append (filter-map
                           identity


### PR DESCRIPTION
The commit 99c60e0d78e8cdec50da0f4b9e3aecfe94e4624d didn't really fix the problem. It fixed the issue of neovim, but produced another issue that ignore the last line of a file on vscode.

That's because I thought `end-line` is exclusive for formatting. But it is not sometimes.

The following example returns `end-line` of 3 files, respectively.

```racket
#lang racket

(require racket/gui/base)

(let ([text (new text%)])
  ;; non-unix os 2 lines file
  (send text insert "0\n1" 0)
  (define end-pos (send text last-position))
  (send text position-paragraph end-pos))

(let ([text (new text%)])
  ;; unix os 2 lines file
  (send text insert "0\n1\n" 0)
  (define end-pos (send text last-position))
  (send text position-paragraph end-pos))

(let ([text (new text%)])
  ;; non-unix os 3 lines file
  (send text insert "0\n1\n2" 0)
  (define end-pos (send text last-position))
  (send text position-paragraph end-pos))
```

it returns

```
1
2
2
```

That means, `end-line` is exclusive for unix style text file (the file ends with a newline), but inclusive for non-unix style text file (the file not ends with a newline). Neovim save files in unix style, but vscode save files in non-unix style by default.

The new definition of `end-line` is always inclusive. I've tested on neovim and vscode, they works fine currently.