### PR TITLE
Fix indentation after new line at first line of expression

### DIFF
--- a/tests/client.rkt
+++ b/tests/client.rkt
@@ -7,7 +7,7 @@
          client-send
          client-wait-response
          make-request
-         make-response
+         make-expected-response
          make-notification)
 
 (require racket/os
@@ -80,7 +80,7 @@
   (cond [(not params) req]
         [else (hash-set req 'params params)]))
 
-(define/contract (make-response request result)
+(define/contract (make-expected-response request result)
   (-> jsexpr? jsexpr? jsexpr?)
 
   (define res

--- a/tests/client.rkt
+++ b/tests/client.rkt
@@ -7,6 +7,7 @@
          client-send
          client-wait-response
          make-request
+         make-response
          make-notification)
 
 (require racket/os
@@ -78,6 +79,15 @@
             'method method))
   (cond [(not params) req]
         [else (hash-set req 'params params)]))
+
+(define/contract (make-response request result)
+  (-> jsexpr? jsexpr? jsexpr?)
+
+  (define res
+    (hasheq 'jsonrpc "2.0"
+            'id (hash-ref request 'id)))
+  (cond [(not result) res]
+        [else (hash-set res 'result result)]))
 
 (define/contract (make-notification method params)
   (-> string? jsexpr? jsexpr?)

--- a/tests/textDocument/formatting.rkt
+++ b/tests/textDocument/formatting.rkt
@@ -45,7 +45,7 @@ END
                                         (hasheq 'line 3
                                                 'character 0)
                                         'ch "\n"))]
-             [res (make-response req
+             [res (make-expected-response req
                                  (list
                                   (hasheq 'range
                                           (hasheq 'start

--- a/tests/textDocument/formatting.rkt
+++ b/tests/textDocument/formatting.rkt
@@ -1,0 +1,67 @@
+#lang racket
+
+(require "with-document.rkt"
+         chk)
+
+(define uri "file:///test.rkt")
+
+(define code
+  #<<END
+#lang racket/base
+
+(define (bob)
+  (+ 1 2))
+END
+  )
+
+(module+ test
+  (with-document "../../main.rkt" uri code
+    (λ (lsp)
+      ;; Insert a new line with indentation after line 2
+      (let ([notif (make-notification
+                    "textDocument/didChange"
+                    (hasheq 'textDocument
+                            (hasheq 'uri uri)
+                            'contentChanges
+                            (list
+                             (hasheq 'range
+                                     (hasheq 'start
+                                             (hasheq 'line 2
+                                                     'character 13)
+                                             'end
+                                             (hasheq 'line 2
+                                                     'character 13))
+                                     'rangeLength 0
+                                     'text "\n"))))])
+        (client-send lsp notif)
+        (client-wait-response lsp))
+
+      ;; Format on type for pre-indented new line 3
+      (let* ([req (make-request lsp
+                                "textDocument/onTypeFormatting"
+                                (hasheq 'textDocument
+                                        (hasheq 'uri uri)
+                                        'position
+                                        (hasheq 'line 3
+                                                'character 0)
+                                        'ch "\n"))]
+             [res (make-response req
+                                 (list
+                                  (hasheq 'range
+                                          (hasheq 'start
+                                                  (hasheq 'line 3
+                                                          'character 0)
+                                                  'end
+                                                  (hasheq 'line 3
+                                                          'character 0))
+                                          'newText "")
+                                  (hasheq 'range
+                                          (hasheq 'start
+                                                  (hasheq 'line 3
+                                                          'character 0)
+                                                  'end
+                                                  (hasheq 'line 3
+                                                          'character 0))
+                                          'newText "  ")))])
+        (client-send lsp req)
+        (chk #:= (client-wait-response lsp) res)))))

--- a/tests/textDocument/with-document.rkt
+++ b/tests/textDocument/with-document.rkt
@@ -4,6 +4,7 @@
          client-send
          client-wait-response
          make-request
+         make-response
          make-notification)
 
 (require "../client.rkt")

--- a/tests/textDocument/with-document.rkt
+++ b/tests/textDocument/with-document.rkt
@@ -4,7 +4,7 @@
          client-send
          client-wait-response
          make-request
-         make-response
+         make-expected-response
          make-notification)
 
 (require "../client.rkt")

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -526,7 +526,7 @@
        (hash-ref open-docs (string->symbol uri)))
      (define indenter (send doc-trace get-indenter))
      (define start-pos (Pos->abs-pos doc-text start))
-     (define end-pos (max 0 (sub1 (Pos->abs-pos doc-text end))))
+     (define end-pos (Pos->abs-pos doc-text end))
      (define start-line (send doc-text position-paragraph start-pos))
      (define end-line (send doc-text position-paragraph end-pos))
      (define mut-doc-text
@@ -584,7 +584,7 @@
       (hash-set params
                 'range range))]
     [_
-     (error-response id INVALID-PARAMS "textDocument/onTypeformatting failed")]))
+     (error-response id INVALID-PARAMS "textDocument/onTypeFormatting failed")]))
 
 ;; Returns a TextEdit, or #f if the line is a part of multiple-line string
 (define (remove-trailing-space! doc-text in-string? line)
@@ -619,7 +619,6 @@
   (cond
     [(not (number? desired-spaces)) #f]
     [(= current-spaces desired-spaces) #f]
-    [(= line-length 0) #f]
     [(< current-spaces desired-spaces)
      ;; Insert spaces
      (define insert-count (- desired-spaces current-spaces))

--- a/text-document.rkt
+++ b/text-document.rkt
@@ -578,7 +578,11 @@
             null
             (append (filter-map
                       identity
-                      ; NOTE: The order is important somehow
+                      ;; NOTE: The order is important here.
+                      ;; `remove-trailing-space!` deletes content relative to the initial document
+                      ;; position. If we were to instead call `indent-line!` first and then
+                      ;; `remove-trailing-space!` second, the remove step could result in
+                      ;; losing user entered code.
                       (list (remove-trailing-space! mut-doc-text skip-this-line? line)
                             (indent-line! mut-doc-text indenter line #:on-type? on-type?)))
                     (loop (add1 line)))))))


### PR DESCRIPTION
Adding a new line at the end of the first line of an existing expression would force you back to the start of the line unexpectedly.

For example, with the following:

```racket
(define (bob); <- place cursor here, then press Return
  (+ 1 2))
```

Previously the langserver left the new line unindented. This fixes the indentation path to instead indent the new line as expected.