### PR TITLE
quick fix bug that introduces in the previous commit

### DIFF
--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -143,7 +143,8 @@
 
     (define/override (syncheck:add-jump-to-definition _src-obj start end id filename _submods)
       (define decl (Decl filename id 0 0))
-      (interval-map-set! sym-bindings start end decl))
+      ;; NOTE start <= end. In some situations, it may be that start = end.
+      (interval-map-set! sym-bindings start (if (= start end) (add1 end) end) decl))
 
     ;; References
     (define/override (syncheck:add-arrow/name-dup _start-src-obj start-left start-right


### PR DESCRIPTION
the start and end coordinates meet the condition `start <= end` not `start < end` which is unusual.
docs: [drracket-tools](https://docs.racket-lang.org/drracket-tools/Accessing_Check_Syntax_Programmatically.html#%28meth._%28%28%28lib._drracket%2Fcheck-syntax..rkt%29._syncheck-annotations~3c~25~3e%29._syncheck~3aadd-require-open-menu%29%29)

My bad. I only tested on toy code, not on more complex codebase.
This bug would cause the server crash infinitely.
I hope no one discovered this until now.