### PR TITLE
fix `textDocument/definition` method

### DIFF
--- a/struct.rkt
+++ b/struct.rkt
@@ -2,13 +2,63 @@
 
 ;; internal structs ;;
 
-(require racket/contract/base)
+(require racket/contract)
 
 (provide
-  (contract-out
-[struct Decl ([filename any/c]
-                        [id any/c]
-                        [left exact-nonnegative-integer?]
-                        [right exact-nonnegative-integer?])]))
+ (contract-out
+  [struct Decl ([filename any/c]
+                [id any/c]
+                [left exact-nonnegative-integer?]
+                [right exact-nonnegative-integer?])]))
 
 (struct Decl (filename id left right) #:transparent)
+
+;; uinteger ;;
+
+(define uinteger-upper-limit (sub1 (expt 2 31)))
+
+(define (uinteger? x)
+  (and (integer? x) (<= 0 x uinteger-upper-limit)))
+
+(provide uinteger?)
+
+;; Position ;;
+
+(struct Position
+  (line character))
+
+(define/contract (make-Position #:line line #:character char)
+  (-> #:line uinteger? #:character uinteger? Position?)
+
+  (Position line char))
+
+(define/contract (Position->hash pos)
+  (-> Position? hash?)
+
+  (hash 'line (Position-line pos)
+        'character (Position-character pos)))
+
+(provide Position
+         make-Position
+         Position->hash)
+
+;; Range ;;
+
+;; `*Range` is a workaround for existing `Range` json expander currently
+(struct *Range
+  (start end))
+
+(define/contract (make-Range #:start start #:end end)
+  (-> #:start Position? #:end Position? *Range?)
+
+  (*Range start end))
+
+(define/contract (Range->hash range)
+  (-> *Range? hash?)
+
+  (hash 'start (Position->hash (*Range-start range))
+        'end (Position->hash (*Range-end range))))
+
+(provide *Range
+         make-Range
+         Range->hash)


### PR DESCRIPTION
I fixed a bug that introduced in previous PR, which caused `textDocument/definition` method cannot return the correct place for the symbol whose definition is in another file.

It basically change the code in `get-definition`

```racket
(start/end->range this-doc start end)
```

to

```
(start/end->range doc-text start end)
```

The a lot of changes happen because `doc-text` is a `lsp-editor%` object, not a `Doc` struct, it can't use `Doc` method.

I also want to push to gradually use internal structs which use contract to make sure they are compatible with lsp specification types.
These structs can also convert from/to jsexpr when necessary. This would avoid the need to build jsexpr everywhere.