### PR TITLE
Refine package dependency

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,13 +3,17 @@
 (define deps '("base"
                "compatibility-lib"
                "data-lib"
+               ;; Newer packages need only to depend on drracket-tool-text-lib.
+               ;; However, we still refer to drracket-tool-lib because it is split
+               ;; into the text- variant starting from Racket 8.4.
                "drracket-tool-lib"
                "gui-lib"
                "syntax-color-lib"
+               "sandbox-lib"  ;; running macro expansion with time limits
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
                ))
-(define build-deps '("chk"))
+(define build-deps '("chk-lib"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")
 (define version "1.0")


### PR DESCRIPTION
- Add `sandbox-lib` to incorporate the use of `with-limits`
- Depend only on `chk-lib` since there's no need to pull `chk-doc`

I had wished that `drracket-tool-lib` could be replaced by `drracket-tool-text-lib`,
but that would break installation on earlier (< 8.4) versions of Racket.
