### PR TITLE
Add a basic GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  build:
+    name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        racket-version: ["7.6", "8.5", "stable", "current"]
+        racket-variant: ["CS"]
+        exclude:
+          - racket-version: "7.6"
+            racket-variant: "CS"
+        include:
+          - racket-version: "7.6"
+            racket-variant: "BC"
+          - racket-version: "8.5"
+            racket-variant: "BC"
+          - racket-version: current
+            experimental: true
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: Bogdanp/setup-racket@v1.10
+        with:
+          architecture: x64
+          distribution: full
+          variant: ${{ matrix.racket-variant }}
+          version: ${{ matrix.racket-version }}
+      - name: Installing racket-langserver and its dependencies
+        run: raco pkg install --no-docs --auto --name racket-langserver
+      - name: Checking the package dependency of racket-langserver
+        run: raco setup -j 1 --no-docs --check-pkg-deps --unused-pkg-deps --pkgs racket-langserver
+      - name: Testing racket-langserver
+        run: xvfb-run -a raco test -j 1 -c racket-langserver/tests

--- a/info.rkt
+++ b/info.rkt
@@ -3,13 +3,17 @@
 (define deps '("base"
                "compatibility-lib"
                "data-lib"
+               ;; Newer packages need only to depend on drracket-tool-text-lib.
+               ;; However, we still refer to drracket-tool-lib because it is split
+               ;; into the text- variant starting from Racket 8.4.
                "drracket-tool-lib"
                "gui-lib"
                "syntax-color-lib"
+               "sandbox-lib"  ;; running macro expansion with time limits
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
                ))
-(define build-deps '("chk"))
+(define build-deps '("chk-lib"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")
 (define version "1.0")


### PR DESCRIPTION
Add a basic CI workflow, running tests with `raco test -j 1 -c racket-langserver/tests`.
(I think GH actions need to be enabled manually in Settings.)

Tested Racket version:
- BC v7.6
- [CS, BC] v8.5
- CS latest release (`stable`)
- CS snapshot (`current`)

The CI depends on the dependency fix in #116. I can rebase after that PR is merged.
