### PR TITLE
rename FormattingOptions fields to racket style

### DIFF
--- a/doc.rkt
+++ b/doc.rkt
@@ -228,7 +228,7 @@
   ;; to respect the given tab size
   (replace-tab! mut-doc-text
                 (max 0 (sub1 start-line))
-                (FormattingOptions-tabSize opts))
+                (FormattingOptions-tab-size opts))
 
   (define indenter-wp (indenter-wrapper indenter mut-doc-text on-type?))
   (define skip-this-line? #f)
@@ -250,7 +250,7 @@
                      ;; position. If we were to instead call `indent-line!` first and then
                      ;; `remove-trailing-space!` second, the remove step could result in
                      ;; losing user entered code.
-                     (list (if (false? (FormattingOptions-trimTrailingWhitespace opts))
+                     (list (if (false? (FormattingOptions-trim-trailing-whitespace opts))
                                #f
                                (remove-trailing-space! mut-doc-text skip-this-line? line))
                            (indent-line! mut-doc-text indenter-wp line)))

--- a/struct.rkt
+++ b/struct.rkt
@@ -92,41 +92,41 @@
          Range->hash)
 
 (struct FormattingOptions
-  (tabSize
-   insertSpaces
-   trimTrailingWhitespace
-   insertFinalNewline
-   trimFinalNewlines
+  (tab-size
+   insert-spaces
+   trim-trailing-whitespace
+   insert-final-newline
+   trim-final-newlines
    key))
 
-(define/contract (make-FormattingOptions #:tabSize tabSize
-                                         #:insertSpaces insertSpaces
-                                         #:trimTrailingWhitespace [trimTrailingWhitespace undef-object]
-                                         #:insertFinalNewline [insertFinalNewline undef-object]
-                                         #:trimFinalNewlines [trimFinalNewlines undef-object]
+(define/contract (make-FormattingOptions #:tab-size tab-size
+                                         #:insert-spaces insert-spaces
+                                         #:trim-trailing-whitespace [trim-trailing-whitespace undef-object]
+                                         #:insert-final-newline [insert-final-newline undef-object]
+                                         #:trim-final-newlines [trim-final-newlines undef-object]
                                          #:key [key undef-object])
-  (-> #:tabSize uinteger?
-      #:insertSpaces boolean?
-      #:trimTrailingWhitespace (undef/c boolean?)
-      #:insertFinalNewline (undef/c boolean?)
-      #:trimFinalNewlines (undef/c boolean?)
+  (-> #:tab-size uinteger?
+      #:insert-spaces boolean?
+      #:trim-trailing-whitespace (undef/c boolean?)
+      #:insert-final-newline (undef/c boolean?)
+      #:trim-final-newlines (undef/c boolean?)
       #:key (undef/c hash?)
       FormattingOptions?)
 
-  (FormattingOptions tabSize
-                     insertSpaces
-                     trimTrailingWhitespace
-                     insertFinalNewline
-                     trimFinalNewlines
+  (FormattingOptions tab-size
+                     insert-spaces
+                     trim-trailing-whitespace
+                     insert-final-newline
+                     trim-final-newlines
                      key))
 
 (define (jsexpr->FormattingOptions jsexpr)
   (with-handlers ([exn:fail? (λ (_) request-err-object)])
-    (make-FormattingOptions #:tabSize (hash-ref jsexpr 'tabSize)
-                            #:insertSpaces (hash-ref jsexpr 'insertSpaces)
-                            #:trimTrailingWhitespace (hash-ref jsexpr 'trimTrailingWhitespace undef-object)
-                            #:insertFinalNewline (hash-ref jsexpr 'insertFinalNewline undef-object)
-                            #:trimFinalNewlines (hash-ref jsexpr 'trimFinalNewlines undef-object)
+    (make-FormattingOptions #:tab-size (hash-ref jsexpr 'tabSize)
+                            #:insert-spaces (hash-ref jsexpr 'insertSpaces)
+                            #:trim-trailing-whitespace (hash-ref jsexpr 'trimTrailingWhitespace undef-object)
+                            #:insert-final-newline (hash-ref jsexpr 'insertFinalNewline undef-object)
+                            #:trim-final-newlines (hash-ref jsexpr 'trimFinalNewlines undef-object)
                             #:key (hash-ref jsexpr 'key undef-object))))
 
 ;; usage:
@@ -145,6 +145,6 @@
               (app jsexpr->FormattingOptions (and name (not (? request-err?)))))])))
 
 (provide FormattingOptions
-         FormattingOptions-tabSize
-         FormattingOptions-trimTrailingWhitespace
+         FormattingOptions-tab-size
+         FormattingOptions-trim-trailing-whitespace
          as-FormattingOptions)


### PR DESCRIPTION
My original idea is to generate all these functions when given a macro

```racket
(define-lsp-type FormattingOptions
  [tabSize uinteger]
  [insertSpaces boolean]
  [trimTrailingWhitespace (undef boolean)]
  [insertFinalNewline (undef boolean)]
  [trimFinalNewlines (undef boolean)]
  [key (undef (object string (or boolean integer string)))])
```

But it finally became very large and unnecessary complex. In this PR, I simply rename all these fields and keywords.