### PR TITLE
fix type error in textDocument/formatting

### DIFF
--- a/doc.rkt
+++ b/doc.rkt
@@ -273,7 +273,7 @@
           [else
            (define line-start (send doc-text line-start-pos line))
            (if indenter
-               (or (indenter doc-text line-start)
+               (or (send doc-text run-indenter indenter line-start)
                    (send doc-text compute-racket-amount-to-indent line-start))
                (send doc-text compute-racket-amount-to-indent line-start))])))
 

--- a/editor.rkt
+++ b/editor.rkt
@@ -97,4 +97,7 @@
     (define/public (compute-racket-amount-to-indent pos)
       (send core compute-racket-amount-to-indent pos))
 
+    (define/public (run-indenter indenter char-pos)
+      (indenter core char-pos))
+
     (super-new)))


### PR DESCRIPTION
This is a mistake in the previous refactor. fix #126 