### PR TITLE
Improve semantic token latency, highlight function and modified variables

### DIFF
--- a/expand.rkt
+++ b/expand.rkt
@@ -1,0 +1,97 @@
+#lang racket/base
+
+(provide read-and-expand)
+
+(require racket/match
+         racket/async-channel
+         syntax/modread
+         syntax/parse
+         drracket/check-syntax)
+
+(define *expander-ch* (make-async-channel))
+
+;; (-> input-port path collector% async-channel)
+;; async-channel receives (list (or syntax #f) (or expand-syntax #f))
+;; where `syntax` is the result of read-syntax,
+;; `expand-syntax` is the result of expand.
+;; They can be #f if error happens during processing.
+(define (read-and-expand in path collector)
+  (define ch (make-async-channel))
+  (async-channel-put *expander-ch* (list path in ch collector))
+  ch)
+
+(define (expander)
+  ;; cache namespace for continuous expand request for same uri
+  (define ns (make-base-namespace))
+  (define last-path #f)
+
+  (let loop ()
+    (match-define (list path in out-ch collector) (sync *expander-ch*))
+
+    (define result
+      (cond [(equal? last-path path)
+             (real-expand path in ns collector)]
+            [else
+             (set! ns (make-base-namespace))
+             (real-expand path in ns collector)]))
+
+    (set! last-path path)
+
+    (async-channel-put out-ch result)
+    (loop)))
+
+(define (real-expand path in ns collector)
+  (define-values (src-dir _1 _2) (split-path path))
+  (define-values (add-syntax done)
+    (make-traversal ns src-dir))
+
+  (parameterize ([current-load-relative-directory src-dir]
+                 [current-namespace ns]
+                 [current-annotations collector])
+    (define stx
+      (with-handlers ([(λ _ #t) (λ (exn) exn)])
+        (with-module-reading-parameterization
+          (lambda () (read-syntax path in)))))
+    (define expanded
+      (with-handlers ([(λ _ #t) (λ (exn) exn)])
+        (with-handlers ([(λ _ #t) (λ _ (expand stx))])
+          (expand (simplify-stx stx)))))
+
+    (when (not (exn? expanded))
+      (add-syntax expanded)
+      (done))
+
+    (list stx expanded)))
+
+(define _expand-th (thread expander))
+
+;; simplify syntax to optimize expand
+;; for example, use typed/racket/no-check language to avoid
+;; type check.
+(define (simplify-stx stx)
+  (define (apply-rules modname)
+    (match modname
+      [(or 'typed/racket/base
+           'typed/racket/base/deep
+           'typed/racket/base/shallow
+           'typed/racket/base/optional)
+       'typed/racket/base/no-check]
+      [(or 'typed/racket
+           'typed/racket/deep
+           'typed/racket/shallow
+           'typed/racket/optional)
+       'typed/racket/no-check]
+      [_ modname]))
+
+  (define (convert name-stx)
+    (define name-sym (syntax->datum name-stx))
+    (if (not (symbol? name-sym))
+        name-stx
+        (datum->syntax name-stx (apply-rules name-sym))))
+
+  (syntax-parse stx
+    [(module id mod-path form ...)
+     (define new-mod (convert #'mod-path))
+     #`(module id #,new-mod form ...)]
+    [stx #'stx]))
+

--- a/expand.rkt
+++ b/expand.rkt
@@ -1,12 +1,19 @@
 #lang racket/base
 
-(provide read-and-expand)
-
 (require racket/match
          racket/async-channel
          syntax/modread
          syntax/parse
-         drracket/check-syntax)
+         drracket/check-syntax
+         racket/contract
+         racket/class)
+
+(provide
+  (contract-out
+    [read-and-expand (-> input-port?
+                         complete-path?
+                         (is-a?/c syncheck-annotations<%>)
+                         async-channel?)]))
 
 (define *expander-ch* (make-async-channel))
 

--- a/highlight.rkt
+++ b/highlight.rkt
@@ -115,26 +115,26 @@
     [(lambda (args ...) expr ...)
      (walk-expanded-stx src #'(expr ...))]
     [(define-values (fs) (lambda _ ...))
-     (append (tags-of-stx-lst src #'(fs) 'function)
+     (append (list (tag-of-expanded-symbol-stx src #'fs 'function))
              (walk-expanded-stx src (drop (syntax-e stx) 2)))]
     [(define-values (names ...) expr)
      (walk-expanded-stx src #'expr)]
     [(#%app proc args ...)
-     (append (tags-of-stx-lst src #'(proc) 'function)
+     (append (list (tag-of-expanded-symbol-stx src #'proc 'function))
              (walk-expanded-stx src #'(args ...)))]
     [(any1 any* ...)
      (append (walk-expanded-stx src #'any1)
              (walk-expanded-stx src #'(any* ...)))]
     [_ (list)]))
 
-(define (tags-of-stx-lst src stx-lst tag)
+(define (tag-of-expanded-symbol-stx src stx tag)
   (define (in-current-file? stx)
     (equal? src (syntax-source stx)))
 
-  (let* ([stx-lst (syntax-e stx-lst)]
-         [stx-lst-in-current-file (filter in-current-file? stx-lst)]
-         [tag-lst (map (λ (stx) (tag-of-atom-stx stx tag)) stx-lst-in-current-file)])
-    tag-lst))
+  (if (and (in-current-file? stx)
+           (symbol? (syntax->datum stx)))
+      (tag-of-atom-stx stx tag)
+      #f))
 
 (define (tag-of-atom-stx atom-stx [expect-tag #f])
   (define pos+1 (syntax-position atom-stx))


### PR DESCRIPTION
This PR added highlight for function and modified variables, and improved expand performance by 30% to 10x.

The details as follows:

* For typed racket, replace its language line with `no-check` language line before expand. It avoid type check and reduce at least one second for each expand. If error happens because of the replace, it would fallback to normal language line.
* Cache namespace. It optimizes for a common scene when people only concentrates on a single file, and don't open other files during the period. In this case, it caches and reuses the namespace of last expand.

This [snippet](https://gist.github.com/6cdh/7d22286f4bd3c5bbaf9375825861cf33) is a demo. For example:

```shell
$ racket fast-expand.rkt path/to/racket-langserver/main.rkt
expand
cpu time: 2196 real time: 2196 gc time: 881
expand2
cpu time: 191 real time: 191 gc time: 71
```

Here the second expand is faster than the first expand by reuses the namespace.

And [a typed racket file](https://github.com/racket/typed-racket/blob/master/typed-racket-test/gui/succeed/racket-esquire.rkt) without the nocheck replacement:

```shell
$ racket fast-expand.rkt path/to/typed-racket/typed-racket-test/gui/succeed/racket-esquire.rkt
expand
cpu time: 2244 real time: 2455 gc time: 792
expand2
cpu time: 1305 real time: 1305 gc time: 392
```

with nocheck replacement:

```shell
$ racket fast-expand.rkt path/to/typed-racket/typed-racket-test/gui/succeed/racket-esquire.rkt
expand
cpu time: 892 real time: 1049 gc time: 324
expand2
cpu time: 226 real time: 226 gc time: 68
```
