### PR TITLE
support `workspace.didChangeWatchedFiles` notification

### DIFF
--- a/methods.rkt
+++ b/methods.rkt
@@ -148,6 +148,8 @@
      (workspace/didRenameFiles params)]
     ["workspace/didChangeWorkspaceFolders"
      (workspace/didChangeWorkspaceFolders params)]
+    ["workspace/didChangeWatchedFiles"
+     (workspace/didChangeWatchedFiles params)]
     ["textDocument/didOpen"
      (text-document/did-open! params)]
     ["textDocument/didClose"

--- a/tests/workspace/did-change-watched-files.rkt
+++ b/tests/workspace/did-change-watched-files.rkt
@@ -1,0 +1,16 @@
+#lang racket
+(require "../client.rkt"
+         chk
+         json)
+
+(module+ test
+  (with-racket-lsp "../../main.rkt"
+    (λ (lsp)
+      (define noti
+        (make-notification "workspace/didChangeWatchedFiles"
+                          (hasheq 'changes
+                                  (list (hasheq 'uri "file:///tmp/test.rkt" 'type 1)   ; created
+                                        (hasheq 'uri "file:///tmp/other.rkt" 'type 2)  ; changed
+                                        (hasheq 'uri "file:///tmp/old.rkt" 'type 3))))) ; deleted
+      (client-send lsp noti)
+      )))


### PR DESCRIPTION
FileChangeType are
* Created = 1
* Changed = 2
* Deleted = 3

misc
* invalid FileChangeType will be ignored
* test notification

resolve #141