### PR TITLE
Add resyntax integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: ["8.15", "stable", "current"]
+        racket-version: ["8.16", "stable", "current"]
         racket-variant: ["CS"]
         include:
           - racket-version: current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,26 @@ jobs:
         run: raco setup -j 1 --no-docs --check-pkg-deps --unused-pkg-deps --pkgs racket-langserver
       - name: Testing racket-langserver
         run: xvfb-run -a raco test -j 1 -c racket-langserver/tests
+
+  resyntax:
+    name: "Resyntax integration on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        racket-version: ["stable"]
+        racket-variant: ["BC", "CS"]
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: Bogdanp/setup-racket@v1.10
+        with:
+          architecture: x64
+          distribution: full
+          variant: ${{ matrix.racket-variant }}
+          version: ${{ matrix.racket-version }}
+      - name: Installing racket-langserver and its dependencies
+        run: raco pkg install --no-docs --auto --name racket-langserver
+      - name: Install Resyntax
+        run: raco pkg install --no-docs --auto resyntax
+      - name: Running resyntax tests
+        run: xvfb-run -a raco test -j 1 tests/textDocument/resyntax/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: ["8.16", "stable", "current"]
-        racket-variant: ["BC", "CS"]
+        racket-version: ["7.6", "8.5", "stable", "current"]
+        racket-variant: ["CS"]
         exclude:
-          - racket-version: "current"
-            racket-variant: "BC"
+          - racket-version: "7.6"
+            racket-variant: "CS"
         include:
+          - racket-version: "7.6"
+            racket-variant: "BC"
+          - racket-version: "8.5"
+            racket-variant: "BC"
           - racket-version: current
             experimental: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         racket-version: ["8.16", "stable", "current"]
-        racket-variant: ["CS"]
+        racket-variant: ["BC", "CS"]
+        exclude:
+          - racket-version: "current"
+            racket-variant: "BC"
         include:
           - racket-version: current
             experimental: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: ["7.6", "8.5", "stable", "current"]
-        racket-variant: ["CS"]
-        exclude:
-          - racket-version: "7.6"
-            racket-variant: "CS"
+        racket-version: ["8.13", "stable", "current"]
+        racket-variant: ["BC", "CS"]
         include:
-          - racket-version: "7.6"
-            racket-variant: "BC"
-          - racket-version: "8.5"
-            racket-variant: "BC"
           - racket-version: current
             experimental: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: ["8.13", "stable", "current"]
-        racket-variant: ["BC", "CS"]
+        racket-version: ["8.15", "stable", "current"]
+        racket-variant: ["CS"]
         include:
           - racket-version: current
             experimental: true

--- a/check-syntax.rkt
+++ b/check-syntax.rkt
@@ -182,6 +182,7 @@
             (set! valid #t)
             (done)
             (send new-trace walk-stx original-stx stx)
+            (send new-trace walk-text text)
             (list)))
         'info)))
 

--- a/doc-trace.rkt
+++ b/doc-trace.rkt
@@ -19,7 +19,7 @@
     (define completions (new completion%))
     (define requires (new require%))
     (define definitions (new definition% [src src]))
-    (define diag (new diag% [doc-text doc-text]))
+    (define diag (new diag% [src src] [doc-text doc-text]))
     (define decls (new declaration%))
     (define semantic-tokens (new highlight% [src src] [doc-text doc-text]))
 
@@ -48,6 +48,10 @@
     (define/public (walk-stx stx expanded-stx)
       (for ([s services])
         (send s walk-stx stx expanded-stx)))
+
+    (define/public (walk-text text)
+      (for ([s services])
+        (send s walk-text text)))
 
     ;; Getters
     (define/public (get-indenter) indenter)

--- a/info.rkt
+++ b/info.rkt
@@ -14,8 +14,6 @@
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
-               "resyntax" ;; for resyntax integration
-               "rebellion" ;; for resyntax integration
                ))
 (define build-deps '("chk-lib"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")

--- a/info.rkt
+++ b/info.rkt
@@ -14,7 +14,8 @@
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
-               "resyntax"
+               "resyntax" ;; for resyntax integration
+               "rebellion" ;; for resyntax integration
                ))
 (define build-deps '("chk-lib"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")

--- a/info.rkt
+++ b/info.rkt
@@ -14,6 +14,7 @@
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
+               "resyntax"
                ))
 (define build-deps '("chk-lib"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")

--- a/methods.rkt
+++ b/methods.rkt
@@ -150,6 +150,8 @@
      (workspace/didChangeWorkspaceFolders params)]
     ["workspace/didChangeWatchedFiles"
      (workspace/didChangeWatchedFiles params)]
+    ["workspace/didChangeConfiguration"
+     (workspace/didChangeConfiguration params)]
     ["textDocument/didOpen"
      (text-document/did-open! params)]
     ["textDocument/didClose"

--- a/service/diagnostic.rkt
+++ b/service/diagnostic.rkt
@@ -8,16 +8,8 @@
          "../responses.rkt"
          "../path-util.rkt"
          "../settings.rkt"
-         drracket/check-syntax)
-
-(require resyntax
-         resyntax/default-recommendations
-         resyntax/private/source
-         resyntax/private/refactoring-result
-         resyntax/private/string-replacement
-         rebellion/base/range
-         rebellion/base/comparator
-         rebellion/collection/range-set)
+         drracket/check-syntax
+         "resyntax.rkt")
 
 (provide diag%)
 
@@ -38,7 +30,7 @@
 
     (define/override (walk-text text)
       (when (get-resyntax-enabled)
-        (resyntax text)))
+        (resyntax text doc-text src warn-diags quickfixs)))
 
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       (when (string=? "no bound occurrences" text)
@@ -76,45 +68,4 @@
                                #:severity Diag-Information
                                #:source "Racket"
                                #:message "unused require"))
-      (set-add! warn-diags diag))
-
-    (define (resyntax text)
-      (define text-source (string-source text))
-      (define all-lines (range-set (unbounded-range #:comparator natural<=>)))
-      (define result-set
-        (resyntax-analyze
-          text-source
-          #:suite default-recommendations
-          #:lines all-lines))
-
-      (define (add result)
-        (define sr (refactoring-result-string-replacement result))
-        (define char-start (string-replacement-start sr))
-        (define char-end (string-replacement-original-end sr))
-        (define message (refactoring-result-message result))
-        (define range (Range #:start (abs-pos->Pos doc-text char-start)
-                             #:end (abs-pos->Pos doc-text char-end)))
-        (define new-text (string-replacement-render sr (source->string text-source)))
-
-        (define rule-name (refactoring-result-rule-name result))
-        (define diag
-          (Diagnostic #:range range
-                      #:severity Diag-Information
-                      #:source "Resyntax"
-                      #:message (format "[~a] ~a" rule-name message)))
-        (define code-action
-          (CodeAction
-            #:title (format "Apply rule [~a]" rule-name)
-            #:kind "quickfix"
-            #:diagnostics (list diag)
-            #:isPreferred #f
-            #:edit (WorkspaceEdit
-                     #:changes
-                     (hasheq (string->symbol (path->uri src))
-                             (list (TextEdit #:range range
-                                             #:newText new-text))))))
-        (set-add! warn-diags diag)
-        (interval-map-set! quickfixs char-start char-end code-action))
-
-      (for-each add (refactoring-result-set-results result-set)))))
-
+      (set-add! warn-diags diag))))

--- a/service/diagnostic.rkt
+++ b/service/diagnostic.rkt
@@ -9,11 +9,20 @@
          "../path-util.rkt"
          drracket/check-syntax)
 
+(require resyntax
+         resyntax/default-recommendations
+         resyntax/private/source
+         resyntax/private/refactoring-result
+         resyntax/private/string-replacement
+         rebellion/base/range
+         rebellion/base/comparator
+         rebellion/collection/range-set)
+
 (provide diag%)
 
 (define diag%
   (class base-service%
-    (init-field doc-text)
+    (init-field src doc-text)
     (super-new)
 
     (define warn-diags (mutable-seteq))
@@ -25,6 +34,9 @@
     (define/override (reset)
       (set-clear! warn-diags)
       (set! quickfixs (make-interval-map)))
+
+    (define/override (walk-text text)
+      (resyntax text))
 
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       (when (string=? "no bound occurrences" text)
@@ -62,5 +74,44 @@
                                #:severity Diag-Information
                                #:source "Racket"
                                #:message "unused require"))
-      (set-add! warn-diags diag))))
+      (set-add! warn-diags diag))
+
+    (define (resyntax text)
+      (define text-source (string-source text))
+      (define all-lines (range-set (unbounded-range #:comparator natural<=>)))
+      (define result-set
+        (resyntax-analyze
+          text-source
+          #:suite default-recommendations
+          #:lines all-lines))
+
+      (define (add result)
+        (define sr (refactoring-result-string-replacement result))
+        (define char-start (string-replacement-start sr))
+        (define char-end (string-replacement-original-end sr))
+        (define message (refactoring-result-message result))
+        (define range (Range #:start (abs-pos->Pos doc-text char-start)
+                             #:end (abs-pos->Pos doc-text char-end)))
+        (define new-text (string-replacement-render sr (source->string text-source)))
+
+        (define diag
+          (Diagnostic #:range range
+                      #:severity Diag-Information
+                      #:source "Resyntax"
+                      #:message message))
+        (define code-action
+          (CodeAction
+            #:title (symbol->string (refactoring-result-rule-name result))
+            #:kind "quickfix"
+            #:diagnostics (list diag)
+            #:isPreferred #f
+            #:edit (WorkspaceEdit
+                     #:changes
+                     (hasheq (string->symbol (path->uri src))
+                             (list (TextEdit #:range range
+                                             #:newText new-text))))))
+        (set-add! warn-diags diag)
+        (interval-map-set! quickfixs char-start char-end code-action))
+
+      (for-each add (refactoring-result-set-results result-set)))))
 

--- a/service/diagnostic.rkt
+++ b/service/diagnostic.rkt
@@ -94,14 +94,15 @@
                              #:end (abs-pos->Pos doc-text char-end)))
         (define new-text (string-replacement-render sr (source->string text-source)))
 
+        (define rule-name (refactoring-result-rule-name result))
         (define diag
           (Diagnostic #:range range
                       #:severity Diag-Information
                       #:source "Resyntax"
-                      #:message message))
+                      #:message (format "[~a] ~a" rule-name message)))
         (define code-action
           (CodeAction
-            #:title (symbol->string (refactoring-result-rule-name result))
+            #:title (format "Apply rule [~a]" rule-name)
             #:kind "quickfix"
             #:diagnostics (list diag)
             #:isPreferred #f

--- a/service/diagnostic.rkt
+++ b/service/diagnostic.rkt
@@ -37,7 +37,7 @@
       (set! quickfixs (make-interval-map)))
 
     (define/override (walk-text text)
-      (when (enable-resyntax?)
+      (when (get-resyntax-enabled)
         (resyntax text)))
 
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)

--- a/service/diagnostic.rkt
+++ b/service/diagnostic.rkt
@@ -7,6 +7,7 @@
          "../interfaces.rkt"
          "../responses.rkt"
          "../path-util.rkt"
+         "../settings.rkt"
          drracket/check-syntax)
 
 (require resyntax
@@ -36,7 +37,8 @@
       (set! quickfixs (make-interval-map)))
 
     (define/override (walk-text text)
-      (resyntax text))
+      (when (enable-resyntax?)
+        (resyntax text)))
 
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       (when (string=? "no bound occurrences" text)

--- a/service/dynamic-import.rkt
+++ b/service/dynamic-import.rkt
@@ -12,7 +12,11 @@
                               (void))])
         (dynamic-require mod 'name logging-fail-thunk)))))
 
-(define-syntax-rule (dynamic-imports mod names ... fail-thunk)
+(define-syntax-rule (dynamic-import-mod mod names ... fail-thunk)
   (begin
     (import-once mod names fail-thunk) ...))
+
+(define-syntax-rule (dynamic-imports (mod names ...) ... fail-thunk)
+  (begin
+    (dynamic-import-mod mod names ... fail-thunk) ...))
 

--- a/service/dynamic-import.rkt
+++ b/service/dynamic-import.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(provide dynamic-imports)
+
+(define-syntax-rule (import-once mod name fail-thunk)
+  (define name
+    (let ([logging-fail-thunk (λ ()
+                                (eprintf "symbol '~a' from module '~a' fail to load.\n" 'name mod)
+                                (fail-thunk))])
+      (with-handlers ([exn? (λ (e)
+                              (logging-fail-thunk)
+                              (void))])
+        (dynamic-require mod 'name logging-fail-thunk)))))
+
+(define-syntax-rule (dynamic-imports mod names ... fail-thunk)
+  (begin
+    (import-once mod names fail-thunk) ...))
+

--- a/service/dynamic-import.rkt
+++ b/service/dynamic-import.rkt
@@ -5,7 +5,7 @@
 (define-syntax-rule (import-once mod name fail-thunk)
   (define name
     (let ([logging-fail-thunk (λ ()
-                                (eprintf "symbol '~a' from module '~a' fail to load.\n" 'name mod)
+                                (log-info "symbol '~a' from module '~a' fail to load." 'name mod)
                                 (fail-thunk))])
       (with-handlers ([exn? (λ (e)
                               (logging-fail-thunk)

--- a/service/interface.rkt
+++ b/service/interface.rkt
@@ -38,5 +38,8 @@
 
     ;; walk original syntax and expanded syntax
     (define/public (walk-stx stx expanded-stx)
+      (void))
+
+    (define/public (walk-text text)
       (void))))
 

--- a/service/resyntax.rkt
+++ b/service/resyntax.rkt
@@ -14,43 +14,30 @@
 (define (disable-resyntax!)
   (set! has-resyntax? #f))
 
-(dynamic-imports 'resyntax/private/source
-                 string-source
-                 source->string
+(dynamic-imports ('resyntax/private/source
+                   string-source
+                   source->string)
+                 ('rebellion/base/range
+                   unbounded-range)
+                 ('rebellion/base/comparator
+                   natural<=>)
+                 ('rebellion/collection/range-set
+                   range-set)
+                 ('resyntax/private/string-replacement
+                   string-replacement-start
+                   string-replacement-original-end
+                   string-replacement-render)
+                 ('resyntax/private/refactoring-result
+                   refactoring-result-string-replacement
+                   refactoring-result-message
+                   refactoring-result-rule-name
+                   refactoring-result-set-results)
+                 ('resyntax/default-recommendations
+                   default-recommendations)
+                 ('resyntax
+                   resyntax-analyze)
                  disable-resyntax!)
 
-(dynamic-imports 'rebellion/base/range
-                 unbounded-range
-                 disable-resyntax!)
-
-(dynamic-imports 'rebellion/base/comparator
-                 natural<=>
-                 disable-resyntax!)
-
-(dynamic-imports 'rebellion/collection/range-set
-                 range-set
-                 disable-resyntax!)
-
-(dynamic-imports 'resyntax/private/string-replacement
-                 string-replacement-start
-                 string-replacement-original-end
-                 string-replacement-render
-                 disable-resyntax!)
-
-(dynamic-imports 'resyntax/private/refactoring-result
-                 refactoring-result-string-replacement
-                 refactoring-result-message
-                 refactoring-result-rule-name
-                 refactoring-result-set-results
-                 disable-resyntax!)
-
-(dynamic-imports 'resyntax/default-recommendations
-                 default-recommendations
-                 disable-resyntax!)
-
-(dynamic-imports 'resyntax
-                 resyntax-analyze
-                 disable-resyntax!)
 
 (define (resyntax text doc-text src warn-diags quickfixs)
   (when has-resyntax?
@@ -95,3 +82,4 @@
     (interval-map-set! quickfixs char-start char-end code-action))
 
   (for-each add (refactoring-result-set-results result-set)))
+

--- a/service/resyntax.rkt
+++ b/service/resyntax.rkt
@@ -1,0 +1,97 @@
+#lang racket/base
+
+(provide resyntax)
+
+(require racket/set
+         data/interval-map
+         "../interfaces.rkt"
+         "../responses.rkt"
+         "../path-util.rkt"
+         "dynamic-import.rkt")
+
+(define has-resyntax? #t)
+
+(define (disable-resyntax!)
+  (set! has-resyntax? #f))
+
+(dynamic-imports 'resyntax/private/source
+                 string-source
+                 source->string
+                 disable-resyntax!)
+
+(dynamic-imports 'rebellion/base/range
+                 unbounded-range
+                 disable-resyntax!)
+
+(dynamic-imports 'rebellion/base/comparator
+                 natural<=>
+                 disable-resyntax!)
+
+(dynamic-imports 'rebellion/collection/range-set
+                 range-set
+                 disable-resyntax!)
+
+(dynamic-imports 'resyntax/private/string-replacement
+                 string-replacement-start
+                 string-replacement-original-end
+                 string-replacement-render
+                 disable-resyntax!)
+
+(dynamic-imports 'resyntax/private/refactoring-result
+                 refactoring-result-string-replacement
+                 refactoring-result-message
+                 refactoring-result-rule-name
+                 refactoring-result-set-results
+                 disable-resyntax!)
+
+(dynamic-imports 'resyntax/default-recommendations
+                 default-recommendations
+                 disable-resyntax!)
+
+(dynamic-imports 'resyntax
+                 resyntax-analyze
+                 disable-resyntax!)
+
+(define (resyntax text doc-text src warn-diags quickfixs)
+  (when has-resyntax?
+    (resyntax-impl text doc-text src warn-diags quickfixs)))
+
+(define (resyntax-impl text doc-text src warn-diags quickfixs)
+  (define text-source (string-source text))
+  (define all-lines (range-set (unbounded-range #:comparator natural<=>)))
+  (define result-set
+    (resyntax-analyze
+      text-source
+      #:suite default-recommendations
+      #:lines all-lines))
+
+  (define (add result)
+    (define sr (refactoring-result-string-replacement result))
+    (define char-start (string-replacement-start sr))
+    (define char-end (string-replacement-original-end sr))
+    (define message (refactoring-result-message result))
+    (define range (Range #:start (abs-pos->Pos doc-text char-start)
+                         #:end (abs-pos->Pos doc-text char-end)))
+    (define new-text (string-replacement-render sr (source->string text-source)))
+
+    (define rule-name (refactoring-result-rule-name result))
+    (define diag
+      (Diagnostic #:range range
+                  #:severity Diag-Information
+                  #:source "Resyntax"
+                  #:message (format "[~a] ~a" rule-name message)))
+    (define code-action
+      (CodeAction
+        #:title (format "Apply rule [~a]" rule-name)
+        #:kind "quickfix"
+        #:diagnostics (list diag)
+        #:isPreferred #f
+        #:edit (WorkspaceEdit
+                 #:changes
+                 (hasheq (string->symbol (path->uri src))
+                         (list (TextEdit #:range range
+                                         #:newText new-text))))))
+    (set-add! warn-diags diag)
+    (interval-map-set! quickfixs char-start char-end code-action))
+
+  (for-each add (refactoring-result-set-results result-set)))

--- a/settings.rkt
+++ b/settings.rkt
@@ -1,6 +1,13 @@
 #lang racket/base
 
-(provide enable-resyntax?)
+(provide get-resyntax-enabled
+         set-resyntax-enabled!)
 
-(define enable-resyntax? (make-parameter #t))
+(define resyntax-enabled? #t)
+
+(define (get-resyntax-enabled)
+  resyntax-enabled?)
+
+(define (set-resyntax-enabled! val)
+  (set! resyntax-enabled? val))
 

--- a/settings.rkt
+++ b/settings.rkt
@@ -1,0 +1,6 @@
+#lang racket/base
+
+(provide enable-resyntax?)
+
+(define enable-resyntax? (make-parameter #t))
+

--- a/tests/textDocument/resyntax/req.json
+++ b/tests/textDocument/resyntax/req.json
@@ -1,0 +1,23 @@
+{
+    "id": 0,
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+        "context": {
+            "diagnostics": []
+        },
+        "range": {
+            "end": {
+                "character": 9,
+                "line": 2
+            },
+            "start": {
+                "character": 8,
+                "line": 2
+            }
+        },
+        "textDocument": {
+            "uri": "file:///test.rkt"
+        }
+    }
+}

--- a/tests/textDocument/resyntax/resp.json
+++ b/tests/textDocument/resyntax/resp.json
@@ -1,0 +1,47 @@
+{
+    "id": 0,
+    "jsonrpc": "2.0",
+    "result": [
+        {
+            "diagnostics": [
+                {
+                    "message": "[format-identity] This use of `format` does nothing.",
+                    "range": {
+                        "end": {
+                            "character": 11,
+                            "line": 2
+                        },
+                        "start": {
+                            "character": 0,
+                            "line": 2
+                        }
+                    },
+                    "severity": 3,
+                    "source": "Resyntax"
+                }
+            ],
+            "edit": {
+                "changes": {
+                    "file:///test.rkt": [
+                        {
+                            "newText": "\"\"",
+                            "range": {
+                                "end": {
+                                    "character": 11,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "character": 0,
+                                    "line": 2
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "isPreferred": false,
+            "kind": "quickfix",
+            "title": "Apply rule [format-identity]"
+        }
+    ]
+}

--- a/tests/textDocument/resyntax/resyntax.rkt
+++ b/tests/textDocument/resyntax/resyntax.rkt
@@ -1,0 +1,30 @@
+#lang racket
+
+(require "../with-document.rkt"
+         "../../../service/dynamic-import.rkt"
+         chk
+         json)
+
+(define uri "file:///test.rkt")
+
+(define code
+  #<<END
+#lang racket/base
+
+(format "")
+END
+  )
+
+;; detect if resyntax is available
+(define has-resyntax? #t)
+(dynamic-imports 'resyntax resyntax-analyze (λ () (set! has-resyntax? #f)))
+
+(module+ test
+  (when has-resyntax?
+    (with-document "../../../main.rkt" uri code
+      (λ (lsp)
+        (let ([req (read-json (open-input-file "req.json"))]
+              [resp (read-json (open-input-file "resp.json"))])
+          (client-send lsp req)
+          (chk #:= (client-wait-response lsp) resp))))))
+

--- a/tests/textDocument/resyntax/resyntax.rkt
+++ b/tests/textDocument/resyntax/resyntax.rkt
@@ -17,7 +17,9 @@ END
 
 ;; detect if resyntax is available
 (define has-resyntax? #t)
-(dynamic-imports 'resyntax resyntax-analyze (λ () (set! has-resyntax? #f)))
+(dynamic-imports ('resyntax
+                   resyntax-analyze)
+                 (λ () (set! has-resyntax? #f)))
 
 (module+ test
   (when has-resyntax?

--- a/tests/textDocument/resyntax/resyntax.rkt
+++ b/tests/textDocument/resyntax/resyntax.rkt
@@ -2,6 +2,7 @@
 
 (require "../with-document.rkt"
          "../../../service/dynamic-import.rkt"
+         "../../../json-util.rkt"
          chk
          json)
 
@@ -25,6 +26,8 @@ END
   (when has-resyntax?
     (with-document "../../../main.rkt" uri code
       (λ (lsp)
+        (define diag (client-wait-response lsp))
+        (chk #:= (jsexpr-ref diag '(method)) "textDocument/publishDiagnostics")
         (let ([req (read-json (open-input-file "req.json"))]
               [resp (read-json (open-input-file "resp.json"))])
           (client-send lsp req)

--- a/workspace.rkt
+++ b/workspace.rkt
@@ -1,9 +1,13 @@
 #lang racket
-(provide didRenameFiles didChangeWorkspaceFolders didChangeWatchedFiles)
+(provide didRenameFiles
+         didChangeWorkspaceFolders
+         didChangeWatchedFiles
+         didChangeConfiguration)
 (require compiler/module-suffix)
 (require "json-util.rkt"
          "doc.rkt"
-         "scheduler.rkt")
+         "scheduler.rkt"
+         "settings.rkt")
 (require "open-docs.rkt")
 
 (define-json-expander FileRename
@@ -77,3 +81,8 @@
   (when (regexp-match (get-module-suffix-regexp) uri)
     (clear-old-queries/doc-close uri)
     (hash-remove! open-docs (string->symbol uri))))
+
+(define (didChangeConfiguration params)
+  (match-define (hash-table ['settings settings]) params)
+  (define client-enable-resyntax (jsexpr-ref settings '(resyntax enable) #t))
+  (enable-resyntax? client-enable-resyntax))

--- a/workspace.rkt
+++ b/workspace.rkt
@@ -11,23 +11,23 @@
 (require "open-docs.rkt")
 
 (define-json-expander FileRename
-                      [oldUri string?]
-                      [newUri string?])
+  [oldUri string?]
+  [newUri string?])
 (define-json-expander RenameFilesParams
-                      [files (listof hash?)])
+  [files (listof hash?)])
 
 (define-json-expander WorkspaceFolder
-                      [uri string?]
-                      [name string?])
+  [uri string?]
+  [name string?])
 (define-json-expander WorkspaceFoldersChangeEvent
-                      [added (listof hash?)]
-                      [removed (listof hash?)])
+  [added (listof hash?)]
+  [removed (listof hash?)])
 
 (define-json-expander FileEvent
-                      [uri string?]
-                      [type exact-positive-integer?])
+  [uri string?]
+  [type exact-positive-integer?])
 (define-json-expander DidChangeWatchedFilesParams
-                      [changes (listof hash?)])
+  [changes (listof hash?)])
 
 (define workspace-folders (mutable-set))
 

--- a/workspace.rkt
+++ b/workspace.rkt
@@ -87,5 +87,5 @@
 
   (define key '(resyntax enable))
   (when (jsexpr-has-key? settings key)
-    (set-resyntax-enabled! (jsexpr-ref settings key #t))))
+    (set-resyntax-enabled! (jsexpr-ref settings key))))
 


### PR DESCRIPTION
This is a initial implementation for #40 .

Some screenshot:

![Screenshot 2025-07-08 232519](https://github.com/user-attachments/assets/9be2a006-5d43-4b89-a58c-68e8d7bb2c6c)

![Screenshot 2025-07-08 232529](https://github.com/user-attachments/assets/577074c6-217b-4bc7-ab04-b55b0dcb2f97)

![Screenshot 2025-07-08 232544](https://github.com/user-attachments/assets/1930e001-ef72-4666-9d49-5aaedb128b0e)

Todo:

- [x] Improve quick fix description
- [x] Implement error handling for unsupported languages
- [x] Incompatibility for old Racket version
- [x] Add a setting to allow editor to enable or disable
- [x] Add test
- [x] Improve latency

For code, I added a new function `walk-text` which provides updated text string to services, it is called every time `check-syntax` succeeds.