### PR TITLE
Add 'racket-doc' to build dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -15,7 +15,8 @@
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
                ))
-(define build-deps '("rackunit-lib"))
+(define build-deps '("rackunit-lib"
+                     "racket-doc"))
 (define pkg-desc "Language Server Protocol implementation for Racket.")
 (define version "1.0")
 


### PR DESCRIPTION
When running `raco setup` (or `raco setup --check-pkg-deps --pkgs racket-langserver`), Raco reports a missing dependency when building `racket-langserver`:

```shell
$ raco setup -j 1 --check-pkg-deps --pkgs racket-langserver
...
raco setup: --- building documentation ---                         [23:37:00]
raco setup: running: <pkgs>/racket-langserver/scribblings/racket-langserver.scrbl
raco setup: rendering: <pkgs>/racket-langserver/scribblings/racket-langserver.scrbl
raco setup: --- installing collections ---                         [23:37:03]
raco setup: --- post-installing collections ---                    [23:37:03]
raco setup: --- checking package dependencies ---                  [23:37:03]
raco setup: found undeclared dependency:
raco setup:   mode: build (of documentation)
raco setup:   for package: "racket-langserver"
raco setup:   on package: "racket-doc"
raco setup:   from document: "racket-langserver"
raco setup:   to document: "reference"
raco setup:   for tag: "(form ((lib \"racket/private/base.rkt\") require))"
raco setup: --- summary of package problems ---                    [23:37:03]
raco setup: undeclared dependency detected
raco setup:   for package: "racket-langserver"
raco setup:   on package for build:
raco setup:    "racket-doc"
```