### PR TITLE
Add external formatter support

### DIFF
--- a/doclib/doc.rkt
+++ b/doclib/doc.rkt
@@ -9,6 +9,7 @@
          "editor.rkt"
          "../common/path-util.rkt"
          "doc-trace.rkt"
+         "formatting.rkt"
          "internal-types.rkt"
          racket/match
          racket/contract
@@ -16,7 +17,6 @@
          racket/set
          racket/list
          racket/string
-         racket/bool
          racket/dict
          data/interval-map
          syntax-color/module-lexer
@@ -349,17 +349,20 @@
 
 ;; formatting ;;
 
+(define (doc-src-dir doc)
+  (with-handlers ([exn:fail? (λ (_exn) #f)])
+    (define doc-path (uri->path (Doc-uri doc)))
+    (define-values (base _name _must-be-dir?) (split-path doc-path))
+    base))
+
 ;; Shared path for all formatting requests
 (define/contract (doc-format-edits doc fmt-range
-                                   #:formatting-options opts
+                                   #:formatting-options _opts
                                    #:on-type? [on-type? #f])
   (->* (Doc? Range? #:formatting-options FormattingOptions?)
        (#:on-type? boolean?)
        (or/c (listof TextEdit?) #f))
   (define doc-text (Doc-text doc))
-  (define doc-trace (Doc-trace doc))
-
-  (define indenter (send doc-trace get-indenter))
   (define start-pos (doc-pos->abs-pos doc (Range-start fmt-range)))
   ;; Adjust for line endings (#92)
   (define end-pos
@@ -367,99 +370,11 @@
          (sub1 (doc-pos->abs-pos doc (Range-end fmt-range)))))
   (define start-line (send doc-text at-line start-pos))
   (define end-line (send doc-text at-line end-pos))
-
-  (define mut-doc-text (send doc-text copy))
-  ;; replace \t with spaces at line `(sub1 start-line)`
-  ;; as we cannot make `compute-racket-amount-to-indent`
-  ;; to respect the given tab size
-  (replace-tab! mut-doc-text
-                (max 0 (sub1 start-line))
-                (FormattingOptions-tab-size opts))
-
-  (define indenter-wp (indenter-wrapper indenter mut-doc-text on-type?))
-  (define skip-this-line? #f)
-
-  (if (eq? indenter 'missing) #f
-      (let loop ([line start-line])
-        (define line-start (send mut-doc-text line-start-pos line))
-        (define line-end (send mut-doc-text line-end-pos line))
-        (for ([i (range line-start (add1 line-end))])
-          (when (and (char=? #\" (send mut-doc-text get-char i))
-                     (not (char=? #\\ (send mut-doc-text get-char (sub1 i)))))
-            (set! skip-this-line? (not skip-this-line?))))
-        (if (> line end-line)
-            null
-            (append (filter-map
-                      values
-                      ;; NOTE: The order is important here.
-                      ;; `remove-trailing-space!` deletes content relative to the initial document
-                      ;; position. If we were to instead call `indent-line!` first and then
-                      ;; `remove-trailing-space!` second, the remove step could result in
-                      ;; losing user entered code.
-                      (list (if (false? (FormattingOptions-trim-trailing-whitespace opts))
-                                #f
-                                (remove-trailing-space! mut-doc-text skip-this-line? line))
-                            (indent-line! mut-doc-text indenter-wp line)))
-                    (loop (add1 line)))))))
-
-(define (replace-tab! doc-text line tabsize)
-  (define old-line (send doc-text get-line line))
-  (define spaces (make-string tabsize #\space))
-  (define new-line-str (string-replace old-line "\t" spaces))
-  (send doc-text replace-in-line
-        new-line-str
-        line 0 (string-length old-line)))
-
-(define (indenter-wrapper indenter doc-text on-type?)
-  (λ (line)
-    (cond [(and (not on-type?)
-                (= (send doc-text line-start-pos line)
-                   (send doc-text line-end-pos line)))
-           #f]
-          [else
-           (define line-start (send doc-text line-start-pos line))
-           (if indenter
-               (or (send doc-text run-indenter indenter line-start)
-                   (send doc-text compute-racket-amount-to-indent line-start))
-               (send doc-text compute-racket-amount-to-indent line-start))])))
-
-;; Returns a TextEdit, or #f if the line is a part of multiple-line string
-(define (remove-trailing-space! doc-text in-string? line)
-  (define line-text (send doc-text get-line line))
-  (cond
-    [(not in-string?)
-     (define from (string-length (string-trim line-text #px"\\s+" #:left? #f)))
-     (define to (string-length line-text))
-     (send doc-text replace-in-line "" line from to)
-     (TextEdit #:range (Range (Pos line from)
-                              (Pos line to))
-               #:newText "")]
-    [else #f]))
-
-(define (extract-indent-string content)
-  (define len
-    (or (for/first ([(c i) (in-indexed content)]
-                    #:when (not (char-whitespace? c)))
-          i)
-        (string-length content)))
-  (substring content 0 len))
-
-;; Returns a TextEdit, or #f if the line is already correct.
-(define (indent-line! doc-text indenter line)
-  (define content (send doc-text get-line line))
-  (define old-indent-string (extract-indent-string content))
-  (define expect-indent (indenter line))
-  (define really-indent (string-length old-indent-string))
-  (define has-tab? (string-contains? old-indent-string "\t"))
-
-  (cond [(false? expect-indent) #f]
-        [(and (= expect-indent really-indent) (not has-tab?)) #f]
-        [else
-         (define new-text (make-string expect-indent #\space))
-         (send doc-text replace-in-line new-text line 0 really-indent)
-         (TextEdit #:range (Range (Pos line 0)
-                                  (Pos line really-indent))
-                   #:newText new-text)]))
+  (formatting (send doc-text get-text)
+              start-line
+              end-line
+              #:src-dir (doc-src-dir doc)
+              #:interactive? on-type?))
 
 ;; get the tokens whose range are contained in interval [pos-start, pos-end)
 ;; the tokens whose range intersects the given range is included.

--- a/doclib/external/fixw.rkt
+++ b/doclib/external/fixw.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(provide get-formatted-lines)
+
+(require fixw/fixw
+         fixw/cli)
+
+(define (get-formatted-lines text src-dir #:interactive? [interactive? #f])
+  (define config
+    (if src-dir
+        (read-config/rec src-dir)
+        #f))
+  (fixw/lines (open-input-string text) config #:interactive? interactive?))
+

--- a/doclib/formatting.rkt
+++ b/doclib/formatting.rkt
@@ -15,6 +15,7 @@
   (for/list ([original-line (in-list original-lines)]
              [formatted-line (in-list formatted-lines)]
              [ln (in-naturals)]
+             #:break (> ln end-ln)
              #:when (and (<= start-ln ln end-ln)
                          (not (string=? original-line formatted-line))))
     (TextEdit #:range (Range (Pos ln 0)

--- a/doclib/formatting.rkt
+++ b/doclib/formatting.rkt
@@ -1,0 +1,27 @@
+#lang racket/base
+
+(require "external/fixw.rkt"
+         "../common/interfaces.rkt"
+         racket/port)
+
+(provide formatting)
+
+(define (formatting text start-ln end-ln #:interactive? [interactive? #f])
+  (define lines (port->lines (open-input-string text)))
+  (define formatted-lines (get-formatted-lines text #:interactive? interactive?))
+  (define diffs (diff-lines lines formatted-lines))
+  (for/list ([diff (in-list diffs)]
+             [ln (in-naturals)]
+             [line (in-list lines)]
+             #:when (and diff (<= start-ln ln end-ln)))
+    (TextEdit #:range (Range (Pos ln 0)
+                             (Pos ln (string-length line)))
+              #:newText diff)))
+
+(define (diff-lines olds news)
+  (for/list ([old (in-list olds)]
+             [new (in-list news)])
+    (if (string=? old new)
+        #f
+        new)))
+

--- a/doclib/formatting.rkt
+++ b/doclib/formatting.rkt
@@ -6,22 +6,18 @@
 
 (provide formatting)
 
-(define (formatting text start-ln end-ln #:interactive? [interactive? #f])
-  (define lines (port->lines (open-input-string text)))
-  (define formatted-lines (get-formatted-lines text #:interactive? interactive?))
-  (define diffs (diff-lines lines formatted-lines))
-  (for/list ([diff (in-list diffs)]
+(define (formatting text start-ln end-ln
+                    #:src-dir [src-dir #f]
+                    #:interactive? [interactive? #f])
+  (define original-lines (port->lines (open-input-string text)))
+  (define formatted-lines
+    (get-formatted-lines text src-dir #:interactive? interactive?))
+  (for/list ([original-line (in-list original-lines)]
+             [formatted-line (in-list formatted-lines)]
              [ln (in-naturals)]
-             [line (in-list lines)]
-             #:when (and diff (<= start-ln ln end-ln)))
+             #:when (and (<= start-ln ln end-ln)
+                         (not (string=? original-line formatted-line))))
     (TextEdit #:range (Range (Pos ln 0)
-                             (Pos ln (string-length line)))
-              #:newText diff)))
-
-(define (diff-lines olds news)
-  (for/list ([old (in-list olds)]
-             [new (in-list news)])
-    (if (string=? old new)
-        #f
-        new)))
+                             (Pos ln (string-length original-line)))
+              #:newText formatted-line)))
 

--- a/info.rkt
+++ b/info.rkt
@@ -14,6 +14,7 @@
                "scribble-lib" ;; for blueboxes (scribble/blueboxes)
                "racket-index" ;; for cross references (setup/xref)
                "html-parsing" ;; for parsing documentation text
+               "fixw" ;; formatter
                ))
 (define build-deps '("rackunit-lib"
                      "racket-doc"

--- a/lsp/text-document.rkt
+++ b/lsp/text-document.rkt
@@ -252,6 +252,28 @@
     [_
      (error-response id ErrorCode-InvalidParams "textDocument/rangeFormatting failed")]))
 
+(define (on-type-formatting-range doc pos ch)
+  (define ch-pos (max 0 (sub1 (doc-pos->abs-pos doc pos))))
+  (define current-line (Pos-line pos))
+  (define current-line-start-pos (doc-line-start-abs-pos doc current-line))
+  (define current-line-end-pos (doc-line-end-abs-pos doc current-line))
+
+  (define (current-line-range)
+    (Range (doc-abs-pos->pos doc current-line-start-pos)
+           (doc-abs-pos->pos doc current-line-end-pos)))
+
+  (define (containing-form-range)
+    (define maybe-paren-pos (doc-find-containing-paren doc (max 0 (sub1 ch-pos))))
+    (define start-pos (if (false? maybe-paren-pos) 0 maybe-paren-pos))
+    (Range (doc-abs-pos->pos doc start-pos)
+           (doc-abs-pos->pos doc current-line-end-pos)))
+
+  (match ch
+    ["\n" (current-line-range)]
+    [")" (containing-form-range)]
+    ["]" (containing-form-range)]
+    [_ (current-line-range)]))
+
 ;; On-type formatting request
 (define (on-type-formatting! id params)
   (match params
@@ -266,20 +288,7 @@
 
      (with-read-doc safe-doc
        (λ (doc)
-         (define ch-pos (- (doc-pos->abs-pos doc pos) 1))
-         (define line (Pos-line pos))
-         (define range
-           (match ch
-             ["\n"
-              (define start (doc-abs-pos->pos doc (doc-line-start-abs-pos doc line)))
-              (define end (doc-abs-pos->pos doc (doc-line-end-abs-pos doc line)))
-              (Range start end)]
-             [_
-              (define start
-                (let ([maybe-paren (doc-find-containing-paren doc (max 0 (sub1 ch-pos)))])
-                  (doc-abs-pos->pos doc (if (false? maybe-paren) 0 maybe-paren))))
-              (define end (doc-abs-pos->pos doc ch-pos))
-              (Range start end)]))
+         (define range (on-type-formatting-range doc pos ch))
          (success/enc
            id
            (doc-format-edits doc range

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -193,7 +193,7 @@
 
   (test-case
     "Formatting"
-    ;; doc.rkt `doc-format-edits` uses `indenter` from trace.
+    ;; doc.rkt `doc-format-edits` delegates to the external formatter.
     (define text "(define x\n1)")
     (define d (make-doc "file:///test.rkt" text))
     (define opts
@@ -204,9 +204,9 @@
                          #:trim-final-newlines #f
                          #:key #f)) ;; tab-size 2
     (define edits (doc-format-edits d (Range (Pos 0 0) (Pos 2 0)) #:formatting-options opts))
-    (check-equal? (length edits) 3)
+    (check-equal? (length edits) 1)
     (check-true (andmap TextEdit? edits))
-    (check-equal? (map TextEdit-newText edits) (list "" "" "  "))
+    (check-equal? (map TextEdit-newText edits) (list "  1)"))
 
     ;; Test with tab size 4
     (define opts4
@@ -217,9 +217,38 @@
                          #:trim-final-newlines #f
                          #:key #f))
     (define edits4 (doc-format-edits d (Range (Pos 0 0) (Pos 2 0)) #:formatting-options opts4))
-    (check-equal? (length edits4) 3)
+    (check-equal? (length edits4) 1)
     (check-true (andmap TextEdit? edits4))
-    (check-equal? (map TextEdit-newText edits4) (list "" "" "  ")))
+    (check-equal? (map TextEdit-newText edits4) (list "  1)")))
+
+  (test-case
+    "Formatting modes"
+    (define opts
+      (FormattingOptions #:tab-size 2
+                         #:insert-spaces #t
+                         #:trim-trailing-whitespace #t
+                         #:insert-final-newline #f
+                         #:trim-final-newlines #f
+                         #:key #f))
+
+    (define normal-doc
+      (make-doc "file:///test.rkt"
+                "#lang racket/base\n\n(define (bob)\n  \n  (+ 1 2))\n"))
+    (check-equal?
+      (doc-format-edits normal-doc
+                        (Range (Pos 3 0) (Pos 4 0))
+                        #:formatting-options opts)
+      (list (TextEdit (Range (Pos 3 0) (Pos 3 2)) "")))
+
+    (define interactive-doc
+      (make-doc "file:///test.rkt"
+                "#lang racket/base\n\n(define (bob)\n\n  (+ 1 2))\n"))
+    (check-equal?
+      (doc-format-edits interactive-doc
+                        (Range (Pos 3 0) (Pos 3 0))
+                        #:on-type? #t
+                        #:formatting-options opts)
+      (list (TextEdit (Range (Pos 3 0) (Pos 3 0)) "  "))))
 
   (test-case
     "Apply TextEdits"
@@ -235,9 +264,7 @@
     (define edits (doc-format-edits d (Range (Pos 0 0) (Pos 2 0)) #:formatting-options opts))
     (check-equal?
       edits
-      (list (TextEdit (Range (Pos 0 9) (Pos 0 9)) "")
-            (TextEdit (Range (Pos 1 2) (Pos 1 2)) "")
-            (TextEdit (Range (Pos 1 0) (Pos 1 0)) "  ")))
+      (list (TextEdit (Range (Pos 1 0) (Pos 1 2)) "  1)")))
     (doc-apply-edits! d edits)
     (check-equal? (doc-get-text d) "(define x\n  1)"))
 

--- a/tests/textDocument/formatting.rkt
+++ b/tests/textDocument/formatting.rkt
@@ -58,14 +58,6 @@ END
                                                             'end
                                                             (hasheq 'line 3
                                                                     'character 0))
-                                                    'newText "")
-                                            (hasheq 'range
-                                                    (hasheq 'start
-                                                            (hasheq 'line 3
-                                                                    'character 0)
-                                                            'end
-                                                            (hasheq 'line 3
-                                                                    'character 0))
                                                     'newText "  ")))])
         (client-send lsp req)
         (check-equal? (jsexpr->string (client-wait-response req)) (jsexpr->string res))))))


### PR DESCRIPTION
This PR switches the existing handwritten formatting logic to external formatters.

Currently, only racket-fixw is integrated because it's error-tolerant, and supports interactive mode.

- For on type formatting, use interactive mode. It indents for empty lines as if there is an atom on these lines based on the context. So if user types `enter`, they are at the indented position, not the beginning of the line.
- For full document and range formatting, use normal mode, that does not indent for empty lines because they are treated as trailing spaces.

Resolve #178

And after this change, we can use a handwritten text buffer to replace `racket:text%` class, and remove the GUI `framework` dependency.