### PR TITLE
Redesign doc lang and diagnostics for language header parsing

### DIFF
--- a/doclib/check-syntax.rkt
+++ b/doclib/check-syntax.rkt
@@ -8,7 +8,10 @@
          racket/port
          "editor.rkt"
          "doc-trace.rkt"
-         "doc-lang.rkt"
+         (only-in "lexer.rkt"
+                  LexerState?
+                  LexerState-language-policy
+                  Language-Policy-expand?)
          "../common/path-util.rkt"
          "internal-types.rkt")
 
@@ -53,11 +56,16 @@
    [succeed? boolean?])
   #:transparent)
 
-(define (check-syntax uri doc-text)
+(define (check-syntax uri doc-text lexer-state)
   (define path (uri->path uri))
   (define text (send doc-text get-text))
-  (define expand? (requires-expansion? path))
-  (define new-trace (new build-trace% [src path] [doc-text doc-text]))
+  (define active-policy (LexerState-language-policy lexer-state))
+  (define expand? (Language-Policy-expand? active-policy))
+  (define new-trace
+    (new build-trace%
+      [src path]
+      [doc-text doc-text]
+      [lexer-state lexer-state]))
 
   (define in (open-input-string text))
   (define er (expand-source path in new-trace #:expand? expand?))
@@ -75,4 +83,4 @@
     [expand-source (->* (path? input-port? (is-a?/c syncheck-annotations<%>))
                         (#:expand? boolean?)
                         ExpandResult?)]
-    [check-syntax (-> string? (is-a?/c lsp-editor%) CSResult?)]))
+    [check-syntax (-> string? (is-a?/c lsp-editor%) LexerState? CSResult?)]))

--- a/doclib/doc-lang.rkt
+++ b/doclib/doc-lang.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require "../common/path-util.rkt"
+(require "../common/interfaces.rkt"
+         "../common/path-util.rkt"
          "lexer/scan.rkt"
          "lexer/snapshot.rkt"
          "lexer/token-tree.rkt"
@@ -10,163 +11,272 @@
          racket/path
          racket/string)
 
-; Base struct for a parsed language declaration.  Holds the language / reader /
-; module-path name extracted from the source, or #f when the declaration is
-; present but malformed (e.g. `#lang` with no language name).
-(struct/contract Language-Declaration
-  ([name (or/c string? #f)])
-  #:transparent)
+;; Turns a document's language declaration into editor policy in two stages:
+;;
+;;   1. Parse the header into a `Language-Header` record.
+;;   2. Match it against the predefined `language-specs` list to produce a
+;;      `Language-Policy` record consumed by diagnostics, formatting,
+;;      expansion, and the lexer.
+;;
+;; Key design choices:
+;;
+;;   - Suffix fallback is used only when no header exists at all.
+;;   - A complete header whose language is not in `language-specs` is kept as
+;;     `unrecognized` rather than guessed.
+;;   - Incomplete headers (started but malformed) produce `#f` for the policy
+;;     language, just like missing headers.
+;;
+;; Recognized header shapes:
+;;
+;;   `#lang <lang ...>`
+;;     Records the full language chain. Pass-through wrappers like
+;;     `errortrace` are skipped to find the policy language.
+;;     e.g. `#lang racket/base`, `#lang typed/racket/base`
+;;
+;;   `#lang reader <payload>`
+;;     Captures the reader payload verbatim. The actual language is
+;;     reader-defined, so no spec can be matched.
+;;     e.g. `#lang reader syntax/module-reader`
+;;
+;;   `#reader <module>`
+;;     Uses the reader module text as the policy selector.
+;;     e.g. `#reader scribble/reader`
+;;
+;;   `(module name lang ...)`
+;;     Uses the module language path as the policy selector.
+;;     e.g. `(module demo racket/base ...)`
 
-; A plain `#lang` directive.  Inherits `name` from Language-Declaration (the
-; language name, e.g. "racket/base").
-(struct/contract HashLang-Declaration Language-Declaration
+;; No recognizable language declaration appeared before the first
+;; non-skippable token. The document may still be matched by file suffix.
+(struct Missing-Header
   ()
   #:transparent)
 
-; A wrapper-shaped `#lang` directive such as `#lang at-exp racket/base`.
-; Inherits `name` from HashLang-Declaration (the wrapper language, e.g.
-; "at-exp"). `delegate-name` records the wrapped language/reader selector.
-(struct/contract WrapperHashLang-Declaration HashLang-Declaration
-  ([delegate-name (or/c string? #f)])
-  #:transparent)
-
-; A `#reader` directive.  Inherits `name` from Language-Declaration (the
-; reader module path, e.g. "scribble/reader").
-(struct/contract Reader-Declaration Language-Declaration
-  ()
-  #:transparent)
-
-; A raw `(module name lang ...)` form.  Inherits `name` from Language-Declaration
-; (the language position in the module form, e.g. "racket/base").
-(struct/contract Module-Declaration Language-Declaration
-  ()
-  #:transparent)
-
-; Describes the language preamble at the top of a source file.  When there is no
-; language declaration at all (#f from parse-language-prefix), no
-; Language-Prefix is constructed and downstream code falls back to
-; guess-language-by-uri (file extension) or #f.
-;   declaration    - the parsed Language-Declaration (Lang-, Reader-, or Module-)
-;   start-pos      - character offset where the preamble begins
-;   end-pos        - character offset where the language-name span ends
-;   body-start-idx - token index into the lexer-span vector where the source code body begins
-(struct/contract Language-Prefix
-  ([declaration Language-Declaration?]
-   [start-pos exact-nonnegative-integer?]
-   [end-pos exact-nonnegative-integer?]
+;; A declaration form was started but contained too few tokens to identify its
+;; language, reader, or module path. `kind` records which syntactic prefix was
+;; recognized (e.g. `#lang`, `#reader`, `module`).
+(struct/contract Incomplete-Header
+  ([kind (or/c 'hash-lang 'hash-lang-reader 'reader 'module)]
+   [range CharRange?]
    [body-start-idx exact-nonnegative-integer?])
   #:transparent)
 
-(struct/contract Known-Language
-  ([name symbol?]
-   [sexp? boolean?]
-   [suffixes (listof string?)]
-   [name-rx regexp?])
+;; A complete `#lang` declaration. The chain may contain pass-through
+;; wrappers like `errortrace`; these are skipped when choosing the
+;; language to use for policy.
+(struct/contract HashLang-Header
+  ([language-chain (and/c (listof string?) (not/c empty?))]
+   [range CharRange?]
+   [body-start-idx exact-nonnegative-integer?])
   #:transparent)
 
-(define (Known-Language~kw #:name name
-                           #:sexp? sexp?
-                           #:suffixes suffixes
-                           #:name-rx name-rx)
-  (Known-Language name sexp? suffixes name-rx))
+;; A complete `#lang reader` declaration. The payload describes a reader, not
+;; a concrete language, so no `Language-Spec` can be selected here.
+(struct/contract HashLangReader-Header
+  ([reader-payload string?]
+   [range CharRange?]
+   [body-start-idx exact-nonnegative-integer?])
+  #:transparent)
 
-(define known-languages
+;; A complete `#reader` declaration. The reader module text that follows
+;; the directive is used directly as the policy selector.
+(struct/contract Reader-Header
+  ([reader-module string?]
+   [range CharRange?]
+   [body-start-idx exact-nonnegative-integer?])
+  #:transparent)
+
+;; A raw `(module name lang ...)` form without a leading reader directive.
+;; The module language path serves as the policy selector.
+(struct/contract Module-Header
+  ([language string?]
+   [range CharRange?]
+   [body-start-idx exact-nonnegative-integer?])
+  #:transparent)
+
+(define Language-Header/c
+  (or/c Missing-Header?
+        Incomplete-Header?
+        HashLang-Header?
+        HashLangReader-Header?
+        Reader-Header?
+        Module-Header?))
+
+;; The single decision record consumed by the rest of doclib.
+;;
+;; The first three fields (status, range, body-start-idx) are direct
+;; header facts for diagnostics. The remaining fields are operational
+;; policy derived from the matched `Language-Spec`.
+(struct/contract Language-Policy
+  ([header-status (or/c 'missing 'incomplete 'complete)]
+   [header-range (or/c CharRange? #f)]
+   [body-start-idx exact-nonnegative-integer?]
+   [policy-language (or/c symbol? 'unrecognized-language #f)]
+   [body-mode (or/c 'sexp 'non-sexp 'unknown)]
+   [format? boolean?]
+   [require-header? boolean?]
+   [expand? boolean?])
+  #:transparent)
+
+;; A known language family. Matched against the header via `name-rx`,
+;; or against the file suffix via `suffixes` when no header is present.
+;;
+;; Fields:
+;;   name            - canonical name, e.g. 'racket, 'scribble
+;;   name-rx         - regex matched against the header language
+;;   suffixes        - file extensions
+;;                     only consulted when no header was found at all
+;;   body-mode       - structural shape of code after the header
+;;                     'sexp, 'non-sexp (e.g. scribble), or 'unknown
+;;   format?         - whether formatting is supported
+;;   require-header? - whether a recognized header is required
+;;   expand?         - whether do macro expansion
+(struct/contract Language-Spec
+  ([name symbol?]
+   [name-rx (or/c regexp? #f)]
+   [suffixes (listof string?)]
+   [body-mode (or/c 'sexp 'non-sexp 'unknown)]
+   [format? boolean?]
+   [require-header? boolean?]
+   [expand? boolean?])
+  #:transparent)
+
+(define (Language-Spec~kw #:name name
+                          #:name-rx name-rx
+                          #:suffixes suffixes
+                          #:body-mode body-mode
+                          #:format? format?
+                          #:require-header? [require-header? #t]
+                          #:expand? [expand? #t])
+  (Language-Spec name name-rx suffixes body-mode format? require-header? expand?))
+
+(define language-specs
   (list
-    (Known-Language~kw #:name 'racket
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^racket(?:/.*)?$")
-    (Known-Language~kw #:name 'typed/racket
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^typed/racket(?:/.*)?$")
-    (Known-Language~kw #:name 'scheme
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^scheme(?:/.*)?$")
-    (Known-Language~kw #:name 'mzscheme
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^mzscheme$")
-    (Known-Language~kw #:name 'r5rs
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^r5rs$")
-    (Known-Language~kw #:name 'r6rs
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^r6rs$")
-    (Known-Language~kw #:name 'r7rs
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^r7rs$")
-    (Known-Language~kw #:name 'lazy
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^lazy$")
-    (Known-Language~kw #:name 'slideshow
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^slideshow$")
-    (Known-Language~kw #:name 'plai
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^plai(?:-typed|-lazy)?$")
-    (Known-Language~kw #:name 'plait
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^plait$")
-    (Known-Language~kw #:name 'htdp
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^htdp/(?:bsl\\+?|isl\\+?|asl)$")
-    (Known-Language~kw #:name 'eopl
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^eopl$")
-    (Known-Language~kw #:name 'sicp
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^sicp$")
-    (Known-Language~kw #:name 'swindle
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^swindle$")
-    (Known-Language~kw #:name 'frtime
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^frtime$")
-    (Known-Language~kw #:name 'rosette
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^rosette(?:/safe)?$")
-    (Known-Language~kw #:name 'pie
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^pie$")
-    (Known-Language~kw #:name 'at-exp
-                       #:sexp? #f
-                       #:suffixes '()
-                       #:name-rx #px"^at-exp$")
-    (Known-Language~kw #:name 's-exp
-                       #:sexp? #t
-                       #:suffixes '()
-                       #:name-rx #px"^s-exp$")
-    (Known-Language~kw #:name 'scribble
-                       #:sexp? #f
-                       #:suffixes '("scrbl")
-                       #:name-rx #px"^scribble(?:/.*)?$")
-    (Known-Language~kw #:name 'rhombus
-                       #:sexp? #f
-                       #:suffixes '("rhm")
-                       #:name-rx #px"^rhombus(?:/.*)?$")))
+    (Language-Spec~kw #:name 'racket
+                      #:name-rx #px"^racket(?:/.*)?$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'typed/racket
+                      #:name-rx #px"^typed/racket(?:/.*)?$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'scheme
+                      #:name-rx #px"^scheme(?:/.*)?$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'mzscheme
+                      #:name-rx #px"^mzscheme$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'r5rs
+                      #:name-rx #px"^r5rs$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'r6rs
+                      #:name-rx #px"^r6rs$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'r7rs
+                      #:name-rx #px"^r7rs$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'lazy
+                      #:name-rx #px"^lazy$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'slideshow
+                      #:name-rx #px"^slideshow$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'plai
+                      #:name-rx #px"^plai(?:-typed|-lazy)?$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'plait
+                      #:name-rx #px"^plait$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'htdp
+                      #:name-rx #px"^htdp/(?:bsl\\+?|isl\\+?|asl)$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'eopl
+                      #:name-rx #px"^eopl$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'sicp
+                      #:name-rx #px"^sicp$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'swindle
+                      #:name-rx #px"^swindle$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'frtime
+                      #:name-rx #px"^frtime$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'rosette
+                      #:name-rx #px"^rosette(?:/safe)?$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'pie
+                      #:name-rx #px"^pie$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'at-exp
+                      #:name-rx #px"^at-exp$"
+                      #:suffixes '()
+                      #:body-mode 'non-sexp
+                      #:format? #f)
+    (Language-Spec~kw #:name 's-exp
+                      #:name-rx #px"^s-exp$"
+                      #:suffixes '()
+                      #:body-mode 'sexp
+                      #:format? #t)
+    (Language-Spec~kw #:name 'scribble
+                      #:name-rx #px"^scribble(?:/.*)?$"
+                      #:suffixes '("scrbl")
+                      #:body-mode 'non-sexp
+                      #:format? #f)
+    (Language-Spec~kw #:name 'rhombus
+                      #:name-rx #px"^rhombus(?:/.*)?$"
+                      #:suffixes '("rhm")
+                      #:body-mode 'non-sexp
+                      #:format? #f)
+    (Language-Spec~kw #:name 'racket-data
+                      #:name-rx #f
+                      #:suffixes '("rktd")
+                      #:body-mode 'unknown
+                      #:format? #f
+                      #:require-header? #f
+                      #:expand? #f)))
 
-(define (source->text+spans source)
-  (cond
-    [(LexerSnapshot? source)
-     (values (LexerSnapshot-text source) (LexerSnapshot-tokens source))]
-    [(string? source)
-     (values source (text->lexer-token-spans source))]))
+(define pass-through-language-names
+  ;; Languages that wrap another without changing editor behavior.
+  ;; They are skipped when picking the policy language.
+  ;; e.g. `#lang errortrace racket/base` behaves like `#lang racket/base`.
+  '("errortrace"))
+
+;; ---- shared text/token helpers -----------------
 
 (define (span-text text span)
   (substring text
@@ -178,47 +288,45 @@
              (token-node-start node)
              (token-node-end node)))
 
-(define (make-language-prefix declaration span body-start-idx)
-  (Language-Prefix declaration
-                   (LexerTokenSpan-start span)
-                   (LexerTokenSpan-end span)
-                   body-start-idx))
+(define (span->range span)
+  (CharRange (LexerTokenSpan-start span)
+             (LexerTokenSpan-end span)))
 
+;; ---- header parsing -------------------------------------------------------
+
+;; Parses the text of a `#lang` directive.
+;;
+;; `#lang reader` owns everything after `reader`, so the payload is
+;; captured verbatim — it is not parsed as a module path here.
+;; The `\\s` regex is intentionally permissive because the lexer may
+;; split `reader` and its payload across lines.
 (define (parse-lang-directive-text text span header-end)
   (match text
-    ;; `#lang reader` takes a reader module path as the rest of the same line.
-    ;; The lexer may include the next line in a bare `#lang reader` error token,
-    ;; so keep the payload match from crossing newlines.
-    [(regexp #px"^#lang\\s+reader[^\\S\r\n]+([^\r\n]+)$"
+    [(regexp #px"^#lang\\s+reader\\s+(\\S.*)$"
              (list _ reader-payload))
-     (make-language-prefix
-       (WrapperHashLang-Declaration "reader" reader-payload)
-       span header-end)]
-    ;; Other two-word `#lang` forms are wrapper + language, including unknown
-    ;; wrappers. Whether the wrapper is recognized affects body mode later.
-    [(regexp #px"^#lang\\s+(\\S+)\\s+(\\S+)$"
-             (list _ wrapper language-name))
-     (make-language-prefix
-       (WrapperHashLang-Declaration wrapper language-name)
-       span header-end)]
-    ;; A single word after `#lang` is the language itself.
-    [(regexp #px"^#lang\\s+(\\S+)$"
-             (list _ language-name))
-     (make-language-prefix
-       (HashLang-Declaration language-name)
-       span header-end)]
+     (HashLangReader-Header reader-payload (span->range span) header-end)]
+    [(regexp #px"^#lang\\s+reader\\s*$")
+     (Incomplete-Header 'hash-lang-reader (span->range span) header-end)]
+    [(regexp #px"^#lang\\s+(\\S.*)$"
+             (list _ chain-text))
+     (define language-chain (string-split chain-text))
+     (and (not (null? language-chain))
+          (HashLang-Header language-chain (span->range span) header-end))]
     [_ #f]))
 
+;; True when `text` starts with `#lang` but couldn't be parsed as a
+;; directive.
 (define (malformed-lang-directive-text? text)
   (and (string? text)
        (string-prefix? text "#lang")))
 
+;; Parses a `#lang` token node. Well-formed directives arrive as
+;; `lang-directive` tokens; malformed or unknown ones arrive as `error`
+;; tokens. The text parser is tried on both so that a complete but
+;; unknown language (e.g. `#lang my-custom-lang`) still produces a
+;; `HashLang-Header`. Only a bare, unparseable `#lang` prefix becomes
+;; an `Incomplete-Header`.
 (define (parse-lang-directive-node text node next-idx)
-  ;; `module-lexer` uses `read-language` to classify language lines: resolved
-  ;; `#lang` forms become `lang-directive`, while failed resolution stays as an
-  ;; `error` token. An error token that still starts with `#lang` may be a
-  ;; recoverable declaration like `#lang reader <module-path>`, or it may be
-  ;; malformed. Try parsing first; then report present-but-malformed `#lang`.
   (match node
     [(Token-Leaf span)
      #:when (eq? 'lang-directive (LexerTokenSpan-type span))
@@ -228,8 +336,12 @@
      (define token-text (span-text text span))
      (or (parse-lang-directive-text token-text span next-idx)
          (and (malformed-lang-directive-text? token-text)
-              (make-language-prefix (HashLang-Declaration #f) span next-idx)))]
+              (Incomplete-Header 'hash-lang (span->range span) next-idx)))]
     [_ #f]))
+
+(define (node->range node)
+  (CharRange (token-node-start node)
+             (token-node-end node)))
 
 (define (leaf-symbol-text text node)
   (match node
@@ -238,10 +350,9 @@
      (span-text text span)]
     [_ #f]))
 
+;; Parses a `#reader` directive. Reads the next non-skippable node as
+;; the reader module; if none follows, the header is incomplete.
 (define (parse-reader-directive-node text spans node next-idx)
-  ;; `read-language` is only for `#lang` lines, so `#reader` lines are handled
-  ;; syntactically. The lexer exposes the marker and the following reader name
-  ;; separately; keep the next non-skippable node as the reader text.
   (match node
     [(Token-Leaf span)
      #:when (eq? 'reader-directive (LexerTokenSpan-type span))
@@ -249,23 +360,19 @@
        (read-next-non-skippable-nodes/spans spans next-idx 1))
      (match reader-nodes
        [(list reader-node)
-        (Language-Prefix (Reader-Declaration (token-node-text text reader-node))
-                         (LexerTokenSpan-start span)
-                         (token-node-end reader-node)
-                         reader-idx)]
+        (Reader-Header (token-node-text text reader-node)
+                       (CharRange (LexerTokenSpan-start span)
+                                  (token-node-end reader-node))
+                       reader-idx)]
        ['()
-        (make-language-prefix
-          (Reader-Declaration #f)
-          span
-          reader-idx)])]
+        (Incomplete-Header 'reader (span->range span) reader-idx)])]
     [_ #f]))
 
+;; Parses a raw `(module name lang ...)` form. Reads three
+;; non-skippable children — the `module` keyword, the module id,
+;; and the language path — and uses the language path as the policy
+;; selector.
 (define (parse-raw-module-node text node start-idx)
-  ;; Raw `(module name lang ...)` forms do not go through `read-language` either,
-  ;; so the language position is syntactic. If the first significant child is
-  ;; `module`, keep the third significant child as the language text even when it
-  ;; names an unknown module path; `parse-language` will decide whether it is
-  ;; known.
   (cond
     [(Token-List? node)
      (define children (token-node-children node))
@@ -273,129 +380,185 @@
        (leaf-symbol-text text node))
      (match (read-next-non-skippable-nodes children 3)
        [(list (app node-symbol-text "module") _mod-id mod-path-node)
-        (Language-Prefix (Module-Declaration (token-node-text text mod-path-node))
-                         (token-node-start node)
-                         (token-node-end mod-path-node)
-                         start-idx)]
+        (Module-Header (token-node-text text mod-path-node)
+                       (CharRange (token-node-start node)
+                                  (token-node-end mod-path-node))
+                       start-idx)]
        [(list (app node-symbol-text "module") _ ...)
-        (Language-Prefix (Module-Declaration #f)
-                         (token-node-start node)
-                         (token-node-end node)
-                         start-idx)]
+        (Incomplete-Header 'module (node->range node) start-idx)]
        [_ #f])]
     [else #f]))
 
-(define (find-language-by-text text)
-  (for/or ([language (in-list known-languages)])
-    (and (regexp-match? (Known-Language-name-rx language) text)
-         language)))
-
-(define/contract (racket-data-file-path? path)
-  (-> path-string? boolean?)
-  (equal? (path-get-extension path) #".rktd"))
-
-(define/contract (requires-expansion? path)
-  (-> path-string? boolean?)
-  (not (racket-data-file-path? path)))
-
-(define/contract (requires-language-declaration? path)
-  (-> path-string? boolean?)
-  (not (racket-data-file-path? path)))
-
-(define (uri->suffix uri)
-  (define extension (path-get-extension (uri->path uri)))
-  (bytes->string/utf-8 (subbytes extension 1)))
-
-(define/contract (guess-language-by-uri uri)
-  (-> (or/c #f string?)
-      (or/c Known-Language? #f))
-  (define maybe-suffix (and uri (uri->suffix uri)))
-  (and maybe-suffix
-       (for/or ([language (in-list known-languages)])
-         (and (member maybe-suffix (Known-Language-suffixes language))
-              language))))
-
-(define (parse-language-prefix-from-spans text spans [idx 0])
+;; Top-level parser. Skips leading whitespace/comments, then tries
+;; `#lang`, `#reader`, and raw `(module ...)` in order. First match
+;; wins; returns `Missing-Header` if none match.
+(define (parse-language-header-from-spans text spans [idx 0])
   (define-values (_skippable-nodes start-idx)
     (parse-skippable-node spans idx))
   (cond
-    [(not (span-at spans start-idx)) #f]
+    [(not (span-at spans start-idx)) (Missing-Header)]
     [else
      (define-values (node next-idx)
        (parse-token-node spans start-idx))
      (or (parse-lang-directive-node text node next-idx)
          (parse-reader-directive-node text spans node next-idx)
-         (parse-raw-module-node text node start-idx))]))
+         (parse-raw-module-node text node start-idx)
+         (Missing-Header))]))
 
-(define/contract (parse-language-prefix source [idx 0])
+(define (source->text+spans source)
+  (cond
+    [(LexerSnapshot? source)
+     (values (LexerSnapshot-text source) (LexerSnapshot-tokens source))]
+    [(string? source)
+     (values source (text->lexer-token-spans source))]))
+
+;; Parse the language header from a source string or lexer snapshot.
+(define/contract (parse-language-header source [idx 0])
   (->* ((or/c string? LexerSnapshot?))
        (exact-nonnegative-integer?)
-       (or/c Language-Prefix? #f))
+       Language-Header/c)
   (define-values (text spans)
     (source->text+spans source))
-  (parse-language-prefix-from-spans text spans idx))
+  (parse-language-header-from-spans text spans idx))
 
-(define (language-declaration-malformed? declaration)
-  (not (Language-Declaration-name declaration)))
+;; ---- language matching ----------------------------------------------------
 
-(define (language-prefix-language-text language-prefix)
-  (Language-Declaration-name
-    (Language-Prefix-declaration language-prefix)))
+(define (pass-through-language-name? name)
+  (and (member name pass-through-language-names)
+       #t))
 
-(define (language-prefix-delegate-text language-prefix)
-  (match (Language-Prefix-declaration language-prefix)
-    [(WrapperHashLang-Declaration _ delegate-name) delegate-name]
-    [_ #f]))
+;; Returns the first non-pass-through language in the chain.
+;; Falls back to the first element if every language is a pass-through
+;; (unusual, but guarantees a name is always available).
+(define (first-non-pass-through language-chain)
+  (or (for/or ([language-name (in-list language-chain)]
+               #:unless (pass-through-language-name? language-name))
+        language-name)
+      (first language-chain)))
 
-(define (language-prefix->language language-prefix uri)
+(define (match-by-language-name name)
+  (and name
+       (for/or ([spec (in-list language-specs)])
+         (and (Language-Spec-name-rx spec)
+              (regexp-match? (Language-Spec-name-rx spec) name)
+              spec))))
+
+(define (uri->suffix uri)
+  (define extension (and uri (path-get-extension (uri->path uri))))
+  (and extension
+       (bytes->string/utf-8 (subbytes extension 1))))
+
+(define (match-by-suffix uri)
+  (define maybe-suffix (uri->suffix uri))
+  (and maybe-suffix
+       (for/or ([spec (in-list language-specs)])
+         (and (member maybe-suffix (Language-Spec-suffixes spec))
+              spec))))
+
+;; Maps a parsed header + optional URI to a `Language-Spec`, or `#f`.
+;; Suffix fallback only applies to `Missing-Header`; incomplete and
+;; reader-defined headers always return `#f`.
+(define/contract (header->language-match header uri)
+  (-> Language-Header/c (or/c #f string?)
+      (or/c Language-Spec? #f))
   (cond
-    [language-prefix
-     ;; In wrapper forms like `#lang at-exp racket/base`, the declaration name
-     ;; is the wrapper language (`at-exp`). The delegate is separate metadata.
-     (define maybe-language-text
-       (language-prefix-language-text language-prefix))
-     (or (and maybe-language-text
-              (find-language-by-text maybe-language-text))
-         'unrecognized-language)]
-    [else (guess-language-by-uri uri)]))
+    [(Missing-Header? header)
+     (match-by-suffix uri)]
+    [(Incomplete-Header? header)
+     #f]
+    [(HashLang-Header? header)
+     (match-by-language-name
+       (first-non-pass-through (HashLang-Header-language-chain header)))]
+    [(HashLangReader-Header? header)
+     #f]
+    [(Reader-Header? header)
+     (match-by-language-name (Reader-Header-reader-module header))]
+    [(Module-Header? header)
+     (match-by-language-name (Module-Header-language header))]))
 
-(define/contract (parse-language source [uri #f])
+;; ---- policy assembly ------------------------------------------------------
+
+;; Chooses the policy language symbol. Returns the spec's name if
+;; matched, `'unrecognized-language` for a complete header with no
+;; matching spec, or `#f` for missing/incomplete headers.
+(define (header+language-match->policy-language header language-match)
+  (cond
+    [(Language-Spec? language-match)
+     (Language-Spec-name language-match)]
+    [(eq? 'complete (header-status header))
+     'unrecognized-language]
+    [else #f]))
+
+(define (language-match->body-mode language-match)
+  (if (Language-Spec? language-match)
+      (Language-Spec-body-mode language-match)
+      'unknown))
+
+(define (language-match-format? language-match)
+  (and (Language-Spec? language-match)
+       (Language-Spec-format? language-match)))
+
+;; Defaults to `#t` when no spec matched. This means languages not in
+;; the predefined list still require a header by default.
+(define (language-match-require-header? language-match)
+  (if (Language-Spec? language-match)
+      (Language-Spec-require-header? language-match)
+      #t))
+
+(define (language-match-expand? language-match)
+  (if (Language-Spec? language-match)
+      (Language-Spec-expand? language-match)
+      #t))
+
+(define (header-status header)
+  (cond
+    [(Missing-Header? header) 'missing]
+    [(Incomplete-Header? header) 'incomplete]
+    [else 'complete]))
+
+(define (header-range header)
+  (cond
+    [(Missing-Header? header) #f]
+    [(Incomplete-Header? header) (Incomplete-Header-range header)]
+    [(HashLang-Header? header) (HashLang-Header-range header)]
+    [(HashLangReader-Header? header) (HashLangReader-Header-range header)]
+    [(Reader-Header? header) (Reader-Header-range header)]
+    [(Module-Header? header) (Module-Header-range header)]))
+
+(define (header-body-start-idx header)
+  (cond
+    [(Missing-Header? header) 0]
+    [(Incomplete-Header? header) (Incomplete-Header-body-start-idx header)]
+    [(HashLang-Header? header) (HashLang-Header-body-start-idx header)]
+    [(HashLangReader-Header? header) (HashLangReader-Header-body-start-idx header)]
+    [(Reader-Header? header) (Reader-Header-body-start-idx header)]
+    [(Module-Header? header) (Module-Header-body-start-idx header)]))
+
+;; Parse a source and derive the full `Language-Policy`. The optional
+;; `uri` enables suffix-based fallback when the header is missing.
+(define/contract (source->language-policy source [uri #f])
   (->* ((or/c string? LexerSnapshot?))
        ((or/c #f string?))
-       (or/c Known-Language? 'unrecognized-language #f))
-  (define prefix (parse-language-prefix source))
-  (language-prefix->language prefix uri))
+       Language-Policy?)
+  (define header (parse-language-header source))
+  (define language-match
+    (header->language-match header uri))
+  (Language-Policy
+    (header-status header)
+    (header-range header)
+    (header-body-start-idx header)
+    (header+language-match->policy-language header language-match)
+    (language-match->body-mode language-match)
+    (language-match-format? language-match)
+    (language-match-require-header? language-match)
+    (language-match-expand? language-match)))
 
-(struct/contract Language-Info
-  ([prefix (or/c Language-Prefix? #f)]
-   [language (or/c Known-Language? 'unrecognized-language #f)]
-   [body-mode (or/c 'sexp 'non-sexp 'unknown)])
-  #:transparent)
-
-(define/contract (lexer-language-info text spans [uri #f])
+;; Same as `source->language-policy` but reuses already-lexed spans.
+(define/contract (lexer-language-policy text spans [uri #f])
   (->* (string? (vectorof LexerTokenSpan?))
        ((or/c #f string?))
-       Language-Info?)
-  (define maybe-prefix (parse-language-prefix-from-spans text spans))
-  (define maybe-language
-    (language-prefix->language maybe-prefix uri))
-  (Language-Info maybe-prefix
-                 maybe-language
-                 (language->body-mode maybe-language)))
-
-(define (language->body-mode maybe-language)
-  (cond
-    [(not (Known-Language? maybe-language)) 'unknown]
-    [(Known-Language-sexp? maybe-language) 'sexp]
-    [else 'non-sexp]))
-
-(define/contract (sexp-language? source [uri #f])
-  (->* ((or/c string? LexerSnapshot?))
-       ((or/c #f string?))
-       boolean?)
-  (define-values (text spans)
-    (source->text+spans source))
-  (eq? 'sexp (Language-Info-body-mode (lexer-language-info text spans uri))))
+       Language-Policy?)
+  (source->language-policy (LexerSnapshot text spans) uri))
 
 (define (indenter-load-failure? e)
   (or (exn:fail:read? e)
@@ -405,35 +568,19 @@
 (define/contract (get-indenter text)
   (-> string? (or/c procedure? #f))
   (with-handlers ([indenter-load-failure? (lambda (_e) #f)])
-    (define maybe-language-info
+    (define maybe-reader-info
       (read-language (open-input-string text) (lambda () #f)))
-    (and (procedure? maybe-language-info)
-         (maybe-language-info 'drracket:indentation #f))))
+    (and (procedure? maybe-reader-info)
+         (maybe-reader-info 'drracket:indentation #f))))
 
-(provide (struct-out Language-Declaration)
-         (struct-out HashLang-Declaration)
-         (struct-out WrapperHashLang-Declaration)
-         (struct-out Reader-Declaration)
-         (struct-out Module-Declaration)
-         (struct-out Language-Prefix)
-         language-declaration-malformed?
-         language-prefix-language-text
-         language-prefix-delegate-text
-         (struct-out Known-Language)
-         Language-Info
-         Language-Info?
-         Language-Info-prefix
-         Language-Info-language
-         Language-Info-body-mode
-         Known-Language~kw
-         known-languages
-         find-language-by-text
-         racket-data-file-path?
-         requires-expansion?
-         requires-language-declaration?
-         parse-language-prefix
-         parse-language
-         guess-language-by-uri
-         lexer-language-info
-         sexp-language?
+(provide (struct-out Missing-Header)
+         (struct-out Incomplete-Header)
+         (struct-out HashLang-Header)
+         (struct-out HashLangReader-Header)
+         (struct-out Reader-Header)
+         (struct-out Module-Header)
+         (struct-out Language-Policy)
+         parse-language-header
+         source->language-policy
+         lexer-language-policy
          get-indenter)

--- a/doclib/doc-lang.rkt
+++ b/doclib/doc-lang.rkt
@@ -10,28 +10,50 @@
          racket/path
          racket/string)
 
-(define language-prefix-source/c
-  (or/c
-    ;; `#lang racket/base`
-    'lang-directive
-    ;; Present `#lang` line with no usable selector.
-    'malformed-lang-directive
-    ;; `#reader scribble/reader`
-    'reader-directive
-    ;; Present `#reader` line with no usable reader.
-    'malformed-reader-directive
-    ;; `#lang reader syntax/module-reader`
-    'reader-lang
-    ;; Present raw `module` form with no language position.
-    'malformed-raw-module
-    ;; `(module name racket/base ...)`
-    'raw-module))
+; Base struct for a parsed language declaration.  Holds the language / reader /
+; module-path name extracted from the source, or #f when the declaration is
+; present but malformed (e.g. `#lang` with no language name).
+(struct/contract Language-Declaration
+  ([name (or/c string? #f)])
+  #:transparent)
 
+; A plain `#lang` directive.  Inherits `name` from Language-Declaration (the
+; language name, e.g. "racket/base").
+(struct/contract HashLang-Declaration Language-Declaration
+  ()
+  #:transparent)
+
+; A wrapper-shaped `#lang` directive such as `#lang at-exp racket/base`.
+; Inherits `name` from HashLang-Declaration (the wrapper language, e.g.
+; "at-exp"). `delegate-name` records the wrapped language/reader selector.
+(struct/contract WrapperHashLang-Declaration HashLang-Declaration
+  ([delegate-name (or/c string? #f)])
+  #:transparent)
+
+; A `#reader` directive.  Inherits `name` from Language-Declaration (the
+; reader module path, e.g. "scribble/reader").
+(struct/contract Reader-Declaration Language-Declaration
+  ()
+  #:transparent)
+
+; A raw `(module name lang ...)` form.  Inherits `name` from Language-Declaration
+; (the language position in the module form, e.g. "racket/base").
+(struct/contract Module-Declaration Language-Declaration
+  ()
+  #:transparent)
+
+; Describes the language preamble at the top of a source file.  When there is no
+; language declaration at all (#f from parse-language-prefix), no
+; Language-Prefix is constructed and downstream code falls back to
+; guess-language-by-uri (file extension) or #f.
+;   declaration    - the parsed Language-Declaration (Lang-, Reader-, or Module-)
+;   start-pos      - character offset where the preamble begins
+;   end-pos        - character offset where the language-name span ends
+;   body-start-idx - token index into the lexer-span vector where the source code body begins
 (struct/contract Language-Prefix
-  ([source language-prefix-source/c]
-   [text string?]
-   [start exact-nonnegative-integer?]
-   [end exact-nonnegative-integer?]
+  ([declaration Language-Declaration?]
+   [start-pos exact-nonnegative-integer?]
+   [end-pos exact-nonnegative-integer?]
    [body-start-idx exact-nonnegative-integer?])
   #:transparent)
 
@@ -122,6 +144,14 @@
                        #:sexp? #t
                        #:suffixes '()
                        #:name-rx #px"^pie$")
+    (Known-Language~kw #:name 'at-exp
+                       #:sexp? #f
+                       #:suffixes '()
+                       #:name-rx #px"^at-exp$")
+    (Known-Language~kw #:name 's-exp
+                       #:sexp? #t
+                       #:suffixes '()
+                       #:name-rx #px"^s-exp$")
     (Known-Language~kw #:name 'scribble
                        #:sexp? #f
                        #:suffixes '("scrbl")
@@ -148,37 +178,36 @@
              (token-node-start node)
              (token-node-end node)))
 
-(define (make-language-prefix source text span body-start-idx)
-  (Language-Prefix source
-                   text
+(define (make-language-prefix declaration span body-start-idx)
+  (Language-Prefix declaration
                    (LexerTokenSpan-start span)
                    (LexerTokenSpan-end span)
                    body-start-idx))
 
 (define (parse-lang-directive-text text span header-end)
-  (or (parse-reader-lang-directive-text text span header-end)
-      (parse-plain-lang-directive-text text span header-end)))
-
-(define (parse-reader-lang-directive-text text span header-end)
-  ;; `#lang reader` is the chaining-reader meta-language, so the payload after
-  ;; `reader` is a module path, not just a single language name token. Once the
-  ;; first line is known to be a `#lang` directive, keep the full text after
-  ;; `reader`, even when `module-lexer` reports the line as `error` in our
-  ;; snapshot setup.
-  (cond
-    [(regexp-match #px"^#lang\\s+reader[ \t]+([^\r\n]+)$" text)
-     => (lambda (match-data)
-          (define reader-payload (second match-data))
-          (make-language-prefix 'reader-lang reader-payload span header-end))]
-    [else #f]))
-
-(define (parse-plain-lang-directive-text text span header-end)
-  (cond
-    [(regexp-match #px"^#lang\\s+(\\S+)$" text)
-     => (lambda (match-data)
-          (define language-name (second match-data))
-          (make-language-prefix 'lang-directive language-name span header-end))]
-    [else #f]))
+  (match text
+    ;; `#lang reader` takes a reader module path as the rest of the same line.
+    ;; The lexer may include the next line in a bare `#lang reader` error token,
+    ;; so keep the payload match from crossing newlines.
+    [(regexp #px"^#lang\\s+reader[^\\S\r\n]+([^\r\n]+)$"
+             (list _ reader-payload))
+     (make-language-prefix
+       (WrapperHashLang-Declaration "reader" reader-payload)
+       span header-end)]
+    ;; Other two-word `#lang` forms are wrapper + language, including unknown
+    ;; wrappers. Whether the wrapper is recognized affects body mode later.
+    [(regexp #px"^#lang\\s+(\\S+)\\s+(\\S+)$"
+             (list _ wrapper language-name))
+     (make-language-prefix
+       (WrapperHashLang-Declaration wrapper language-name)
+       span header-end)]
+    ;; A single word after `#lang` is the language itself.
+    [(regexp #px"^#lang\\s+(\\S+)$"
+             (list _ language-name))
+     (make-language-prefix
+       (HashLang-Declaration language-name)
+       span header-end)]
+    [_ #f]))
 
 (define (malformed-lang-directive-text? text)
   (and (string? text)
@@ -186,10 +215,10 @@
 
 (define (parse-lang-directive-node text node next-idx)
   ;; `module-lexer` uses `read-language` to classify language lines: resolved
-  ;; `#lang` forms become `lang-directive`, while failed resolution stays
-  ;; `error`. Preserve that distinction for plain `#lang`, but still recover
-  ;; `#lang reader ...` from `error` tokens because its payload is a module path
-  ;; that may be useful even when the chained reader cannot be loaded.
+  ;; `#lang` forms become `lang-directive`, while failed resolution stays as an
+  ;; `error` token. An error token that still starts with `#lang` may be a
+  ;; recoverable declaration like `#lang reader <module-path>`, or it may be
+  ;; malformed. Try parsing first; then report present-but-malformed `#lang`.
   (match node
     [(Token-Leaf span)
      #:when (eq? 'lang-directive (LexerTokenSpan-type span))
@@ -198,10 +227,8 @@
      #:when (eq? 'error (LexerTokenSpan-type span))
      (define token-text (span-text text span))
      (or (parse-lang-directive-text token-text span next-idx)
-         ;; Explicitly recognize `#lang` error tokens as malformed language
-         ;; directives.
          (and (malformed-lang-directive-text? token-text)
-              (make-language-prefix 'malformed-lang-directive "" span next-idx)))]
+              (make-language-prefix (HashLang-Declaration #f) span next-idx)))]
     [_ #f]))
 
 (define (leaf-symbol-text text node)
@@ -222,13 +249,15 @@
        (read-next-non-skippable-nodes/spans spans next-idx 1))
      (match reader-nodes
        [(list reader-node)
-        (Language-Prefix 'reader-directive
-                         (token-node-text text reader-node)
+        (Language-Prefix (Reader-Declaration (token-node-text text reader-node))
                          (LexerTokenSpan-start span)
                          (token-node-end reader-node)
                          reader-idx)]
        ['()
-        (make-language-prefix 'malformed-reader-directive "" span reader-idx)])]
+        (make-language-prefix
+          (Reader-Declaration #f)
+          span
+          reader-idx)])]
     [_ #f]))
 
 (define (parse-raw-module-node text node start-idx)
@@ -244,14 +273,12 @@
        (leaf-symbol-text text node))
      (match (read-next-non-skippable-nodes children 3)
        [(list (app node-symbol-text "module") _mod-id mod-path-node)
-        (Language-Prefix 'raw-module
-                         (token-node-text text mod-path-node)
+        (Language-Prefix (Module-Declaration (token-node-text text mod-path-node))
                          (token-node-start node)
                          (token-node-end mod-path-node)
                          start-idx)]
        [(list (app node-symbol-text "module") _ ...)
-        (Language-Prefix 'malformed-raw-module
-                         ""
+        (Language-Prefix (Module-Declaration #f)
                          (token-node-start node)
                          (token-node-end node)
                          start-idx)]
@@ -308,10 +335,27 @@
     (source->text+spans source))
   (parse-language-prefix-from-spans text spans idx))
 
+(define (language-declaration-malformed? declaration)
+  (not (Language-Declaration-name declaration)))
+
+(define (language-prefix-language-text language-prefix)
+  (Language-Declaration-name
+    (Language-Prefix-declaration language-prefix)))
+
+(define (language-prefix-delegate-text language-prefix)
+  (match (Language-Prefix-declaration language-prefix)
+    [(WrapperHashLang-Declaration _ delegate-name) delegate-name]
+    [_ #f]))
+
 (define (language-prefix->language language-prefix uri)
   (cond
     [language-prefix
-     (or (find-language-by-text (Language-Prefix-text language-prefix))
+     ;; In wrapper forms like `#lang at-exp racket/base`, the declaration name
+     ;; is the wrapper language (`at-exp`). The delegate is separate metadata.
+     (define maybe-language-text
+       (language-prefix-language-text language-prefix))
+     (or (and maybe-language-text
+              (find-language-by-text maybe-language-text))
          'unrecognized-language)]
     [else (guess-language-by-uri uri)]))
 
@@ -333,26 +377,25 @@
        ((or/c #f string?))
        Language-Info?)
   (define maybe-prefix (parse-language-prefix-from-spans text spans))
-  (define maybe-language (language-prefix->language maybe-prefix uri))
-  (define body-mode
-    (cond
-      [(and (Known-Language? maybe-language)
-            (Known-Language-sexp? maybe-language))
-       'sexp]
-      [(Known-Language? maybe-language)
-       'non-sexp]
-      [else 'unknown]))
+  (define maybe-language
+    (language-prefix->language maybe-prefix uri))
   (Language-Info maybe-prefix
                  maybe-language
-                 body-mode))
+                 (language->body-mode maybe-language)))
+
+(define (language->body-mode maybe-language)
+  (cond
+    [(not (Known-Language? maybe-language)) 'unknown]
+    [(Known-Language-sexp? maybe-language) 'sexp]
+    [else 'non-sexp]))
 
 (define/contract (sexp-language? source [uri #f])
   (->* ((or/c string? LexerSnapshot?))
        ((or/c #f string?))
        boolean?)
-  (define maybe-language (parse-language source uri))
-  (and (Known-Language? maybe-language)
-       (Known-Language-sexp? maybe-language)))
+  (define-values (text spans)
+    (source->text+spans source))
+  (eq? 'sexp (Language-Info-body-mode (lexer-language-info text spans uri))))
 
 (define (indenter-load-failure? e)
   (or (exn:fail:read? e)
@@ -367,8 +410,15 @@
     (and (procedure? maybe-language-info)
          (maybe-language-info 'drracket:indentation #f))))
 
-(provide (struct-out Language-Prefix)
-         language-prefix-source/c
+(provide (struct-out Language-Declaration)
+         (struct-out HashLang-Declaration)
+         (struct-out WrapperHashLang-Declaration)
+         (struct-out Reader-Declaration)
+         (struct-out Module-Declaration)
+         (struct-out Language-Prefix)
+         language-declaration-malformed?
+         language-prefix-language-text
+         language-prefix-delegate-text
          (struct-out Known-Language)
          Language-Info
          Language-Info?

--- a/doclib/doc-trace.rkt
+++ b/doclib/doc-trace.rkt
@@ -14,13 +14,16 @@
 
 (define build-trace%
   (class (annotations-mixin object%)
-    (init-field src doc-text)
+    (init-field src doc-text lexer-state)
     (define hovers (new hover%))
     (define docs (new docs%))
     (define completions (new completion%))
     (define requires (new require%))
     (define definitions (new definition% [src src]))
-    (define diag (new diag% [src src] [doc-text doc-text]))
+    (define diag (new diag%
+                   [src src]
+                   [doc-text doc-text]
+                   [lexer-state lexer-state]))
     (define decls (new declaration%))
     (define workspace-references (new workspace-references% [src src] [doc-text doc-text]))
     (define semantic-tokens (new highlight% [src src] [doc-text doc-text]))

--- a/doclib/doc.rkt
+++ b/doclib/doc.rkt
@@ -313,6 +313,9 @@
 (define (doc-language-policy doc)
   (LexerState-language-policy (doc-lexer-state doc)))
 
+(define (doc-language-body-mode doc)
+  (Language-Policy-body-mode (doc-language-policy doc)))
+
 (define (doc-body-forest doc)
   (lexer-state-body-forest (doc-lexer-state doc)))
 
@@ -360,7 +363,7 @@
   (values start-line (max start-line (min requested-end-line last-line))))
 
 (define (doc-sexp-language? doc)
-  (eq? 'sexp (Language-Info-body-mode (doc-language-info doc))))
+  (eq? 'sexp (doc-language-body-mode doc)))
 
 (define (doc-on-type-formatting-range doc pos ch)
   (define ch-pos (max 0 (sub1 (doc-pos->abs-pos doc pos))))
@@ -885,7 +888,7 @@
   ;; so any symbol the walker produced would have a bogus range. Report no
   ;; symbols instead. Unknown languages keep the sexp treatment, matching the
   ;; lexer fallback used elsewhere.
-  (if (eq? (Language-Info-body-mode (doc-language-info doc)) 'non-sexp)
+  (if (eq? (doc-language-body-mode doc) 'non-sexp)
       '()
       (doc-symbols-hierarchical/sexp doc)))
 

--- a/doclib/doc.rkt
+++ b/doclib/doc.rkt
@@ -46,8 +46,13 @@
        Doc?)
   (define doc-text (new lsp-editor%))
   (send doc-text insert text 0)
+  (define lexer-state (build-lexer-state text uri))
   ;; the init trace should not be #f
-  (define doc-trace (new build-trace% [src (uri->path uri)] [doc-text doc-text]))
+  (define doc-trace
+    (new build-trace%
+      [src (uri->path uri)]
+      [doc-text doc-text]
+      [lexer-state lexer-state]))
   (Doc uri doc-text doc-trace version #f (list) (make-lazy-cache)))
 
 (define (invalidate-resyntax-results! doc)
@@ -186,9 +191,9 @@
                                 (text-edit-end doc edit)
                                 (TextEdit-newText edit)))))
 
-(define/contract (doc-expand uri doc-text)
-  (-> string? (is-a?/c lsp-editor%) CSResult?)
-  (check-syntax uri doc-text))
+(define/contract (doc-expand uri doc-text lexer-state)
+  (-> string? (is-a?/c lsp-editor%) LexerState? CSResult?)
+  (check-syntax uri doc-text lexer-state))
 
 (define/contract (doc-update-trace! doc new-trace new-version)
   (-> Doc? (is-a?/c build-trace%) exact-nonnegative-integer? void?)
@@ -201,7 +206,10 @@
 
 (define/contract (doc-expand! doc)
   (-> Doc? boolean?)
-  (define result (doc-expand (Doc-uri doc) (Doc-text doc)))
+  (define result
+    (doc-expand (Doc-uri doc)
+                (Doc-text doc)
+                (doc-lexer-state doc)))
   (define new-trace (CSResult-trace result))
   (cond [(CSResult-succeed? result)
          (doc-update-trace! doc new-trace (Doc-version doc))
@@ -292,8 +300,8 @@
 (define (doc-lexer-snapshot doc)
   (LexerState-snapshot (doc-lexer-state doc)))
 
-(define (doc-language-info doc)
-  (LexerState-language-info (doc-lexer-state doc)))
+(define (doc-language-policy doc)
+  (LexerState-language-policy (doc-lexer-state doc)))
 
 (define (doc-body-forest doc)
   (lexer-state-body-forest (doc-lexer-state doc)))
@@ -352,8 +360,9 @@
   (define-values (start-line end-line)
     (formatting-range->lines doc-text fmt-range))
   (define text (send doc-text get-text))
+  (define policy (doc-language-policy doc))
   (cond
-    [(sexp-language? text (Doc-uri doc))
+    [(Language-Policy-format? policy)
      (formatting text
                  start-line
                  end-line
@@ -774,7 +783,7 @@
          doc-range-tokens
          doc-token-at
          doc-token-prefix-at
-         doc-language-info
+         doc-language-policy
          doc-body-forest
          doc-expand
          doc-update-trace!

--- a/doclib/lexer.rkt
+++ b/doclib/lexer.rkt
@@ -13,7 +13,7 @@
          build-lexer-state
          LexerState?
          LexerState-snapshot
-         LexerState-language-info
+         LexerState-language-policy
          lexer-state-body-mode
          lexer-state-token-at
          lexer-state-symbol-at
@@ -26,9 +26,5 @@
          for-each-lexer-snapshot-entry
          lexer-snapshot-token-at
          lexer-snapshot-symbol-at
-         lexer-language-info
-         Language-Info
-         Language-Info?
-         Language-Info-prefix
-         Language-Info-language
-         Language-Info-body-mode)
+         lexer-language-policy
+         (struct-out Language-Policy))

--- a/doclib/lexer/state.rkt
+++ b/doclib/lexer/state.rkt
@@ -9,12 +9,12 @@
          "tree-query.rkt"
          racket/contract)
 
-;; `LexerState` groups the flat snapshot, language metadata, and a lazy
+;; `LexerState` groups the flat snapshot, language policy, and a lazy
 ;; body-forest cache. Documents keep one LexerState instead of separate caches
 ;; for snapshot, language, and forest.
 (struct/contract LexerState
   ([snapshot LexerSnapshot?]
-   [language-info Language-Info?]
+   [language-policy Language-Policy?]
    [body-forest-cache (lazy-cache-of Token-Forest?)])
   #:transparent)
 
@@ -24,18 +24,13 @@
   (LexerSnapshot text token-span-vector))
 
 (define (lexer-state-body-mode state)
-  (Language-Info-body-mode (LexerState-language-info state)))
+  (Language-Policy-body-mode (LexerState-language-policy state)))
 
-(define (language-info-body-start-idx info)
-  (cond [(Language-Info-prefix info)
-         => Language-Prefix-body-start-idx]
-        [else 0]))
-
-(define (forest-range-for-language-info info spans)
+(define (forest-range-for-language-policy policy spans)
   (define total (vector-length spans))
-  (define body-start-idx (language-info-body-start-idx info))
+  (define body-start-idx (Language-Policy-body-start-idx policy))
   (cond
-    [(eq? 'non-sexp (Language-Info-body-mode info))
+    [(eq? 'non-sexp (Language-Policy-body-mode policy))
      (values 0 body-start-idx)]
     [else
      (values (if (and (< body-start-idx total)
@@ -44,31 +39,31 @@
                  0)
              total)]))
 
-(define (build-token-forest-for-language-info info spans)
+(define (build-token-forest-for-language-policy policy spans)
   (define-values (start end)
-    (forest-range-for-language-info info spans))
+    (forest-range-for-language-policy policy spans))
   (parse-token-forest spans start end))
 
-;; Build a token forest from token spans. Uses language info to decide what
+;; Build a token forest from token spans. Uses language policy to decide what
 ;; portion of the spans to parse: for non-sexp languages only the prefix is
 ;; parsed; for sexp languages, the body starting at body-start-idx is parsed.
 (define (build-snapshot-token-forest text uri spans)
-  (define info (lexer-language-info text spans uri))
-  (build-token-forest-for-language-info info spans))
+  (define policy (lexer-language-policy text spans uri))
+  (build-token-forest-for-language-policy policy spans))
 
 (define (build-lexer-state text uri)
   (define snapshot (build-lexer-snapshot text uri))
-  (define info (lexer-language-info (LexerSnapshot-text snapshot)
-                                    (LexerSnapshot-tokens snapshot)
-                                    uri))
-  (LexerState snapshot info (make-lazy-cache)))
+  (define policy (lexer-language-policy (LexerSnapshot-text snapshot)
+                                        (LexerSnapshot-tokens snapshot)
+                                        uri))
+  (LexerState snapshot policy (make-lazy-cache)))
 
 (define (lexer-state-body-forest state)
   (call-with-lazy-cache!
     (LexerState-body-forest-cache state)
     (lambda ()
-      (build-token-forest-for-language-info
-        (LexerState-language-info state)
+      (build-token-forest-for-language-policy
+        (LexerState-language-policy state)
         (LexerSnapshot-tokens (LexerState-snapshot state))))))
 
 (define/contract (lexer-state-token-at state pos)

--- a/doclib/service/diagnostic.rkt
+++ b/doclib/service/diagnostic.rkt
@@ -233,7 +233,19 @@
     (match (regexp-match #rx"collection: \"([^\"]+)\"" msg)
       [(list _ collection) collection]
       [_ #f]))
+  (define maybe-language
+    (and maybe-module-path
+         (match (regexp-match #rx"^(.+)/lang/reader$" maybe-module-path)
+           [(list _ language) language]
+           [_ #f])))
   (cond
+    [maybe-language
+     (format (string-append
+               "Cannot find language \"~a\".\n"
+               "  module path: ~a\n"
+               "Check that the language name is correct and the package is installed.")
+             maybe-language
+             maybe-module-path)]
     [(and maybe-module-path maybe-collection)
      (format (string-append
                "Cannot find module \"~a\" in collection \"~a\".\n"

--- a/doclib/service/diagnostic.rkt
+++ b/doclib/service/diagnostic.rkt
@@ -192,6 +192,10 @@
     ;; Turn each reported srcloc into a diagnostic, falling back to the first
     ;; line only when Racket reports the error without a usable position.
     [(exn:srclocs? exn)
+     (define diagnostic-msg
+       (if (exn:missing-module? exn)
+           (missing-module-message msg)
+           msg))
      (define srclocs ((exn:srclocs-accessor exn) exn))
      (for/list ([sl (in-list srclocs)])
        (match-define (srcloc src line col pos span) sl)
@@ -202,28 +206,44 @@
                                         #:end (Pos #:line (sub1 line) #:char (+ col span))))
                        #:severity DiagnosticSeverity-Error
                        #:source "Racket"
-                       #:message msg)
+                       #:message diagnostic-msg)
            ;; Some reader exceptions don't report a position
            (Diagnostic #:range (first-line-range doc-text)
                        #:severity DiagnosticSeverity-Error
                        #:source "Racket"
-                       #:message msg)))]
+                       #:message diagnostic-msg)))]
     ;; Missing module exceptions tell us which module could not be loaded, but
     ;; not which `require` form in the user's file triggered the lookup. Publish
     ;; the message at a document-level range instead of guessing the require.
     [(exn:missing-module? exn)
-     ;; Hack:
-     ;; We do not have any source location for the offending `require`, but the language
-     ;; server protocol requires a valid range object. So highlight the first line.
-     ;; This is very close to DrRacket's behavior:  it also has no source location to work with,
-     ;; however it simply doesn't highlight any code.
      (list (Diagnostic #:range (first-line-range doc-text)
                        #:severity DiagnosticSeverity-Error
                        #:source "Racket"
-                       #:message msg))]
+                       #:message (missing-module-message msg)))]
     ;; If a new kind of expansion failure reaches this point, fail loudly so we
     ;; can decide how to map it into an LSP diagnostic.
     [else (error 'error-diagnostics "unexpected failure: ~a" exn)]))
+
+(define (missing-module-message msg)
+  (define maybe-module-path
+    (match (regexp-match #rx"for module path: ([^\n]+)" msg)
+      [(list _ module-path) module-path]
+      [_ #f]))
+  (define maybe-collection
+    (match (regexp-match #rx"collection: \"([^\"]+)\"" msg)
+      [(list _ collection) collection]
+      [_ #f]))
+  (cond
+    [(and maybe-module-path maybe-collection)
+     (format (string-append
+               "Cannot find module \"~a\" in collection \"~a\".\n"
+               "Check that the module name is correct and the package is installed.")
+             maybe-module-path
+             maybe-collection)]
+    [else
+     (string-append
+       "Cannot find required module.\n"
+       "Check that the module or collection name is correct and the package is installed.")]))
 
 (define (check-typed-racket-log doc-text log)
   (match-define (vector _ msg data _) log)

--- a/doclib/service/diagnostic.rkt
+++ b/doclib/service/diagnostic.rkt
@@ -99,7 +99,6 @@
 
 (define language-diagnostic-source "Language Declaration Check")
 
-;; Return a diagnostic for a missing or unrecognized source language declaration.
 (define (language-diagnostic doc-text)
   (define text (send doc-text get-text))
   (define maybe-language-prefix (parse-language-prefix text))
@@ -107,12 +106,13 @@
     [(not maybe-language-prefix)
      (language-error-diag
        (first-line-range doc-text)
-       "Missing language declaration. Add a `#lang` line, `#reader`, or `(module ... <language> ...)` form.")]
-    [(find-language-by-text (Language-Prefix-text maybe-language-prefix)) #f]
-    [else
+       "Missing language header. Start the file with `#lang <language>`, `#reader <reader>`, or `(module <name> <language> ...)`.")]
+    [(language-declaration-malformed?
+       (Language-Prefix-declaration maybe-language-prefix))
      (language-error-diag
        (language-prefix-range doc-text maybe-language-prefix)
-       (unrecognized-language-message maybe-language-prefix))]))
+       "Incomplete language header. Provide the missing language or reader name.")]
+    [else #f]))
 
 (define (language-error-diag range message)
   (Diagnostic #:range range
@@ -140,18 +140,8 @@
 (define (language-prefix-range doc-text language-prefix)
   (nonempty-diagnostic-range
     doc-text
-    (Range #:start (abs-pos->Pos doc-text (Language-Prefix-start language-prefix))
-           #:end (abs-pos->Pos doc-text (Language-Prefix-end language-prefix)))))
-
-(define (unrecognized-language-message language-prefix)
-  (define language-text (Language-Prefix-text language-prefix))
-  (cond
-    [(not (string=? "" language-text))
-     (format
-       "Unrecognized language declaration `~a`. Check the language name or reader path."
-       language-text)]
-    [else
-     "Unrecognized language declaration. Check the language name after `#lang`, `#reader`, or in `(module ... <language> ...)`."]))
+    (Range #:start (abs-pos->Pos doc-text (Language-Prefix-start-pos language-prefix))
+           #:end (abs-pos->Pos doc-text (Language-Prefix-end-pos language-prefix)))))
 
 (define (error-diagnostics doc-text exn)
   (define msg (exn-message exn))

--- a/doclib/service/diagnostic.rkt
+++ b/doclib/service/diagnostic.rkt
@@ -10,7 +10,11 @@
          data/interval-map
          "../../common/interfaces.rkt"
          "../internal-types.rkt"
-         "../doc-lang.rkt"
+         (only-in "../lexer.rkt"
+                  LexerState-language-policy
+                  Language-Policy-header-range
+                  Language-Policy-header-status
+                  Language-Policy-require-header?)
          "../../common/path-util.rkt"
          drracket/check-syntax)
 
@@ -18,7 +22,7 @@
 
 (define diag%
   (class base-service%
-    (init-field src doc-text)
+    (init-field src doc-text lexer-state)
     (super-new)
 
     (define diags (mutable-seteq))
@@ -43,8 +47,7 @@
       (define pre-exn (ExpandResult-pre-exn expand-result))
       (define post-exn (ExpandResult-post-exn expand-result))
       (define maybe-language-diag
-        (and (requires-language-declaration? src)
-             (language-diagnostic doc-text)))
+        (language-diagnostic doc-text (LexerState-language-policy lexer-state)))
       (when maybe-language-diag
         (add-diag! maybe-language-diag))
       (when pre-exn
@@ -97,20 +100,19 @@
                                #:message "unused require"))
       (add-diag! diag))))
 
-(define language-diagnostic-source "Language Declaration Check")
+(define language-diagnostic-source "Language Header Check")
 
-(define (language-diagnostic doc-text)
-  (define text (send doc-text get-text))
-  (define maybe-language-prefix (parse-language-prefix text))
+(define (language-diagnostic doc-text policy)
   (cond
-    [(not maybe-language-prefix)
+    [(not (Language-Policy-require-header? policy))
+     #f]
+    [(eq? 'missing (Language-Policy-header-status policy))
      (language-error-diag
        (first-line-range doc-text)
        "Missing language header. Start the file with `#lang <language>`, `#reader <reader>`, or `(module <name> <language> ...)`.")]
-    [(language-declaration-malformed?
-       (Language-Prefix-declaration maybe-language-prefix))
+    [(eq? 'incomplete (Language-Policy-header-status policy))
      (language-error-diag
-       (language-prefix-range doc-text maybe-language-prefix)
+       (language-header-range doc-text (Language-Policy-header-range policy))
        "Incomplete language header. Provide the missing language or reader name.")]
     [else #f]))
 
@@ -137,11 +139,11 @@
   (Range #:start (abs-pos->Pos doc-text start)
          #:end (abs-pos->Pos doc-text end)))
 
-(define (language-prefix-range doc-text language-prefix)
+(define (language-header-range doc-text char-range)
   (nonempty-diagnostic-range
     doc-text
-    (Range #:start (abs-pos->Pos doc-text (Language-Prefix-start-pos language-prefix))
-           #:end (abs-pos->Pos doc-text (Language-Prefix-end-pos language-prefix)))))
+    (Range #:start (abs-pos->Pos doc-text (CharRange-start char-range))
+           #:end (abs-pos->Pos doc-text (CharRange-end char-range)))))
 
 (define (error-diagnostics doc-text exn)
   (define msg (exn-message exn))

--- a/lsp/safedoc.rkt
+++ b/lsp/safedoc.rkt
@@ -8,6 +8,7 @@
 (require "../common/rwlock.rkt"
          "../doclib/doc.rkt"
          "../doclib/check-syntax.rkt"
+         "../doclib/lexer.rkt"
          "../doclib/external/resyntax.rkt"
          "resyntax-place.rkt"
          "scheduler.rkt"
@@ -112,7 +113,9 @@
           (send-doc-diagnostics notify-client doc)))))
 
   (define (check-syntax-task)
-    (define result (doc-expand uri text-buffer-copy))
+    (define text (send text-buffer-copy get-text))
+    (define lexer-state (build-lexer-state text uri))
+    (define result (doc-expand uri text-buffer-copy lexer-state))
 
     (with-write-safedoc safe-doc
       (lambda (sd)

--- a/tests/lib/doc-lang-test.rkt
+++ b/tests/lib/doc-lang-test.rkt
@@ -16,8 +16,19 @@
     (and (Known-Language? language)
          (Known-Language-name language)))
 
-  (define (prefix source text end body-start-idx)
-    (Language-Prefix source text 0 end body-start-idx))
+  (define (language-info text)
+    (define snapshot (build-lexer-snapshot text))
+    (lexer-language-info (LexerSnapshot-text snapshot)
+                         (LexerSnapshot-tokens snapshot)))
+
+  (define (prefix declaration end body-start-idx)
+    (Language-Prefix declaration 0 end body-start-idx))
+
+  (define (lang-prefix text end body-start-idx)
+    (prefix (HashLang-Declaration text) end body-start-idx))
+
+  (define (wrapped-lang-prefix wrapper delegate-text end body-start-idx)
+    (prefix (WrapperHashLang-Declaration wrapper delegate-text) end body-start-idx))
 
   (test-case
     "Known-Language has a keyword constructor"
@@ -32,14 +43,33 @@
     "parse-language-prefix recognizes an ordinary #lang line"
     (check-equal?
       (parse-prefix "#lang racket/base\n(define x 1)\n")
-      (prefix 'lang-directive "racket/base" (string-length "#lang racket/base") 1)))
+      (lang-prefix "racket/base" (string-length "#lang racket/base") 1)))
+
+  (test-case
+    "parse-language-prefix recognizes wrapped #lang lines"
+    (check-equal?
+      (parse-prefix "#lang at-exp racket\n@(define x 1)\n")
+      (wrapped-lang-prefix "at-exp"
+                           "racket"
+                           (string-length "#lang at-exp racket")
+                           1))
+    (check-equal?
+      (parse-prefix "#lang s-exp racket/base\n(define x 1)\n")
+      (wrapped-lang-prefix "s-exp"
+                           "racket/base"
+                           (string-length "#lang s-exp racket/base")
+                           1))
+    (check-equal?
+      (parse-prefix "#lang unknown-wrapper racket/base\n(define x 1)\n")
+      (lang-prefix "unknown-wrapper"
+                   (string-length "#lang unknown-wrapper")
+                   1)))
 
   (test-case
     "parse-language-prefix recognizes #lang reader wrappers"
     (check-equal?
       (parse-prefix "#lang reader syntax/module-reader\nracket/base\n")
-      (prefix 'reader-lang
-              "syntax/module-reader"
+      (prefix (WrapperHashLang-Declaration "reader" "syntax/module-reader")
               (string-length "#lang reader syntax/module-reader")
               1)))
 
@@ -47,22 +77,21 @@
     "parse-language-prefix keeps the full payload after #lang reader"
     (check-equal?
       (parse-prefix "#lang reader \"literal.rkt\"\nhello\n")
-      (prefix 'reader-lang
-              "\"literal.rkt\""
+      (prefix (WrapperHashLang-Declaration "reader" "\"literal.rkt\"")
               (string-length "#lang reader \"literal.rkt\"")
               1))
     (check-equal?
       (parse-prefix
         "#lang reader (submod syntax/module-reader reader)\n1\n")
-      (prefix 'reader-lang
-              "(submod syntax/module-reader reader)"
+      (prefix (WrapperHashLang-Declaration
+                "reader"
+                "(submod syntax/module-reader reader)")
               (string-length
                 "#lang reader (submod syntax/module-reader reader)")
               1))
     (check-equal?
       (parse-prefix "#lang reader (foo)\n1\n")
-      (prefix 'reader-lang
-              "(foo)"
+      (prefix (WrapperHashLang-Declaration "reader" "(foo)")
               (string-length "#lang reader (foo)")
               1)))
 
@@ -70,14 +99,12 @@
     "parse-language-prefix recognizes #reader directives"
     (check-equal?
       (parse-prefix "#reader scribble/reader\n@title{demo}\n")
-      (prefix 'reader-directive
-              "scribble/reader"
+      (prefix (Reader-Declaration "scribble/reader")
               (string-length "#reader scribble/reader")
               3))
     (check-equal?
       (parse-prefix "#reader (reader demo)\nbody\n")
-      (prefix 'reader-directive
-              "(reader demo)"
+      (prefix (Reader-Declaration "(reader demo)")
               (string-length "#reader (reader demo)")
               7)))
 
@@ -85,20 +112,17 @@
     "parse-language-prefix recognizes raw modules"
     (check-equal?
       (parse-prefix "(module demo typed/racket/base (define x 1))\n")
-      (prefix 'raw-module
-              "typed/racket/base"
+      (prefix (Module-Declaration "typed/racket/base")
               (string-length "(module demo typed/racket/base")
               0))
     (check-equal?
       (parse-prefix "(module demo (lib \"racket/base\") (define x 1))\n")
-      (prefix 'raw-module
-              "(lib \"racket/base\")"
+      (prefix (Module-Declaration "(lib \"racket/base\")")
               (string-length "(module demo (lib \"racket/base\")")
               0))
     (check-equal?
       (parse-prefix "(module demo \"literal.rkt\" (define x 1))\n")
-      (prefix 'raw-module
-              "\"literal.rkt\""
+      (prefix (Module-Declaration "\"literal.rkt\"")
               (string-length "(module demo \"literal.rkt\"")
               0)))
 
@@ -106,42 +130,44 @@
     "parse-language-prefix skips leading comments and sexp comments"
     (check-equal?
       (parse-prefix "; preamble\n#; (define ignored 1)\n#lang rhombus\nfun f(): 1\n")
-      (Language-Prefix 'lang-directive "rhombus" 33 46 13)))
+      (Language-Prefix (HashLang-Declaration "rhombus")
+                       33
+                       46
+                       13)))
 
   (test-case
     "parse-language-prefix reports present but unrecognized selectors"
     (check-equal? (parse-prefix "#lang \n(define x 1)\n")
-                  (prefix 'malformed-lang-directive "" (string-length "#lang ") 1))
+                  (prefix (HashLang-Declaration #f)
+                          (string-length "#lang ")
+                          1))
     (check-equal? (parse-prefix "#lang reader\n(define x 1)\n")
-                  (prefix 'malformed-lang-directive ""
+                  (prefix (HashLang-Declaration #f)
                           (string-length "#lang reader\n(define x 1)")
                           1))
     (check-equal? (parse-prefix "#lang not-a-real-language\n1\n")
-                  (prefix 'lang-directive
-                          "not-a-real-language"
-                          (string-length "#lang not-a-real-language")
-                          1))
+                  (lang-prefix "not-a-real-language"
+                               (string-length "#lang not-a-real-language")
+                               1))
     (check-equal? (parse-prefix "#reader\n")
-                  (prefix 'malformed-reader-directive "" (string-length "#reader") 2))
+                  (prefix (Reader-Declaration #f)
+                          (string-length "#reader")
+                          2))
     (check-equal? (parse-prefix "#reader does/not/exist\n")
-                  (prefix 'reader-directive
-                          "does/not/exist"
+                  (prefix (Reader-Declaration "does/not/exist")
                           (string-length "#reader does/not/exist")
                           3))
     (check-equal? (parse-prefix "(module demo does/not/exist (define x 1))\n")
-                  (prefix 'raw-module
-                          "does/not/exist"
+                  (prefix (Module-Declaration "does/not/exist")
                           (string-length "(module demo does/not/exist")
                           0))
     (check-equal? (parse-prefix "(module demo 1 (define x 1))\n")
-                  (prefix 'raw-module
-                          "1"
+                  (prefix (Module-Declaration "1")
                           (string-length "(module demo 1")
                           0))
     (check-equal? (parse-prefix "(module demo)\n")
                   (Language-Prefix
-                    'malformed-raw-module
-                    ""
+                    (Module-Declaration #f)
                     0
                     (string-length "(module demo)")
                     0))
@@ -183,7 +209,10 @@
                   'scribble)
     (check-equal? (language-name "#lang rhombus\nfun f(): 1\n")
                   'rhombus)
-    (check-false (parse-known-language "#lang s-exp racket/base\n1\n"))
+    (check-equal? (language-name "#lang at-exp racket\n@(define x 1)\n")
+                  'at-exp)
+    (check-equal? (language-name "#lang s-exp racket/base\n1\n")
+                  's-exp)
     (check-equal? (parse-known-language "#lang not-a-real-language\n1\n")
                   'unrecognized-language)
     (check-equal? (parse-known-language "#reader does/not/exist\n")
@@ -207,6 +236,10 @@
                   'rosette)
     (check-equal? (Known-Language-name (find-language-by-text "pie"))
                   'pie)
+    (check-equal? (Known-Language-name (find-language-by-text "at-exp"))
+                  'at-exp)
+    (check-equal? (Known-Language-name (find-language-by-text "s-exp"))
+                  's-exp)
     (check-false (find-language-by-text "plai/foo"))
     (check-false (find-language-by-text "htdp/bsl/foo"))
     (check-false (find-language-by-text "rosette/unsafe"))
@@ -231,6 +264,18 @@
     (check-equal? (Known-Language-name (guess-language-by-uri "file:///tmp/demo.scrbl"))
                   'scribble)
     (check-false (guess-language-by-uri "file:///tmp/demo.rkt")))
+
+  (test-case
+    "wrapped #lang lines classify wrapper languages and body mode"
+    (define at-exp-info (language-info "#lang at-exp racket\n@(define x 1)\n"))
+    (check-equal? (Known-Language-name (Language-Info-language at-exp-info))
+                  'at-exp)
+    (check-equal? (Language-Info-body-mode at-exp-info) 'non-sexp)
+
+    (define s-exp-info (language-info "#lang s-exp racket/base\n(define x 1)\n"))
+    (check-equal? (Known-Language-name (Language-Info-language s-exp-info))
+                  's-exp)
+    (check-equal? (Language-Info-body-mode s-exp-info) 'sexp))
 
   (test-case
     "rktd files are Racket data, not expandable modules"
@@ -258,8 +303,9 @@
     (check-true (sexp-language? "#lang htdp/isl+\n(define x 1)\n"))
     (check-true (sexp-language? "#lang rosette\n(define x 1)\n"))
     (check-true (sexp-language? "#lang pie\n(claim n Nat)\n"))
+    (check-true (sexp-language? "#lang s-exp racket/base\n(define x 1)\n"))
     (check-false (sexp-language? "#lang plai/foo\n(define x 1)\n"))
-    (check-false (sexp-language? "#lang s-exp racket/base\n(define x 1)\n"))
+    (check-false (sexp-language? "#lang at-exp racket\n@(define x 1)\n"))
     (check-false (sexp-language? "#lang scribble/manual\n@title{demo}\n"))
     (check-false (sexp-language? "fun f(): 1\n" "file:///tmp/demo.rhm"))
     (check-false (sexp-language? "(define x 1)\n" "file:///tmp/demo.rkt"))))

--- a/tests/lib/doc-lang-test.rkt
+++ b/tests/lib/doc-lang-test.rkt
@@ -2,186 +2,158 @@
 
 (module+ test
   (require rackunit
+           "../../common/interfaces.rkt"
            "../../doclib/doc-lang.rkt"
            "../../doclib/lexer.rkt")
 
-  (define (parse-prefix text)
-    (parse-language-prefix (build-lexer-snapshot text)))
+  (define (parse-header text)
+    (parse-language-header (build-lexer-snapshot text)))
 
-  (define (parse-known-language text [uri #f])
-    (parse-language (build-lexer-snapshot text) uri))
+  (define (policy text [uri #f])
+    (source->language-policy (build-lexer-snapshot text) uri))
 
-  (define (language-name text [uri #f])
-    (define language (parse-known-language text uri))
-    (and (Known-Language? language)
-         (Known-Language-name language)))
+  (define (range start end)
+    (CharRange start end))
 
-  (define (language-info text)
-    (define snapshot (build-lexer-snapshot text))
-    (lexer-language-info (LexerSnapshot-text snapshot)
-                         (LexerSnapshot-tokens snapshot)))
+  (define (header-range text)
+    (range 0 (string-length text)))
 
-  (define (prefix declaration end body-start-idx)
-    (Language-Prefix declaration 0 end body-start-idx))
-
-  (define (lang-prefix text end body-start-idx)
-    (prefix (HashLang-Declaration text) end body-start-idx))
-
-  (define (wrapped-lang-prefix wrapper delegate-text end body-start-idx)
-    (prefix (WrapperHashLang-Declaration wrapper delegate-text) end body-start-idx))
-
-  (test-case
-    "Known-Language has a keyword constructor"
-    (check-equal?
-      (Known-Language~kw #:name 'demo
-                         #:sexp? #t
-                         #:suffixes '("demo")
-                         #:name-rx #px"^demo$")
-      (Known-Language 'demo #t '("demo") #px"^demo$")))
+  (define (check-policy text
+                        #:uri [uri #f]
+                        #:status status
+                        #:language language
+                        #:body-mode body-mode
+                        #:format? format?
+                        #:require-header? require-header?
+                        #:expand? expand?)
+    (define actual (policy text uri))
+    (check-equal? (Language-Policy-header-status actual) status)
+    (check-equal? (Language-Policy-policy-language actual) language)
+    (check-equal? (Language-Policy-body-mode actual) body-mode)
+    (check-equal? (Language-Policy-format? actual) format?)
+    (check-equal? (Language-Policy-require-header? actual) require-header?)
+    (check-equal? (Language-Policy-expand? actual) expand?))
 
   (test-case
-    "parse-language-prefix recognizes an ordinary #lang line"
+    "parse-language-header recognizes ordinary hash-lang headers"
     (check-equal?
-      (parse-prefix "#lang racket/base\n(define x 1)\n")
-      (lang-prefix "racket/base" (string-length "#lang racket/base") 1)))
+      (parse-header "#lang racket/base\n(define x 1)\n")
+      (HashLang-Header '("racket/base")
+                       (header-range "#lang racket/base")
+                       1)))
 
   (test-case
-    "parse-language-prefix recognizes wrapped #lang lines"
+    "parse-language-header keeps hash-lang language chains"
     (check-equal?
-      (parse-prefix "#lang at-exp racket\n@(define x 1)\n")
-      (wrapped-lang-prefix "at-exp"
-                           "racket"
-                           (string-length "#lang at-exp racket")
-                           1))
+      (parse-header "#lang at-exp racket\n@(define x 1)\n")
+      (HashLang-Header '("at-exp" "racket")
+                       (header-range "#lang at-exp racket")
+                       1))
     (check-equal?
-      (parse-prefix "#lang s-exp racket/base\n(define x 1)\n")
-      (wrapped-lang-prefix "s-exp"
-                           "racket/base"
-                           (string-length "#lang s-exp racket/base")
-                           1))
+      (parse-header "#lang s-exp racket/base\n(define x 1)\n")
+      (HashLang-Header '("s-exp" "racket/base")
+                       (header-range "#lang s-exp racket/base")
+                       1))
     (check-equal?
-      (parse-prefix "#lang unknown-wrapper racket/base\n(define x 1)\n")
-      (lang-prefix "unknown-wrapper"
-                   (string-length "#lang unknown-wrapper")
-                   1)))
+      (parse-header "#lang errortrace at-exp racket/base\n@(define x 1)\n")
+      (HashLang-Header '("errortrace" "at-exp" "racket/base")
+                       (header-range "#lang errortrace at-exp racket/base")
+                       1))
+    (check-equal?
+      (parse-header "#lang unknown-wrapper racket/base\n(define x 1)\n")
+      (HashLang-Header '("unknown-wrapper")
+                       (header-range "#lang unknown-wrapper")
+                       1)))
 
   (test-case
-    "parse-language-prefix recognizes #lang reader wrappers"
+    "parse-language-header recognizes #lang reader headers"
     (check-equal?
-      (parse-prefix "#lang reader syntax/module-reader\nracket/base\n")
-      (prefix (WrapperHashLang-Declaration "reader" "syntax/module-reader")
-              (string-length "#lang reader syntax/module-reader")
-              1)))
+      (parse-header "#lang reader syntax/module-reader\nracket/base\n")
+      (HashLangReader-Header "syntax/module-reader"
+                             (header-range "#lang reader syntax/module-reader")
+                             1))
+    (check-equal?
+      (parse-header "#lang reader\nsyntax/module-reader\nracket/base\n")
+      (HashLangReader-Header "syntax/module-reader"
+                             (header-range "#lang reader\nsyntax/module-reader")
+                             1))
+    (check-equal?
+      (parse-header "#lang reader \"literal.rkt\"\nhello\n")
+      (HashLangReader-Header "\"literal.rkt\""
+                             (header-range "#lang reader \"literal.rkt\"")
+                             1))
+    (check-equal?
+      (parse-header "#lang reader (submod syntax/module-reader reader)\n1\n")
+      (HashLangReader-Header
+        "(submod syntax/module-reader reader)"
+        (header-range "#lang reader (submod syntax/module-reader reader)")
+        1)))
 
   (test-case
-    "parse-language-prefix keeps the full payload after #lang reader"
+    "parse-language-header recognizes #reader directives"
     (check-equal?
-      (parse-prefix "#lang reader \"literal.rkt\"\nhello\n")
-      (prefix (WrapperHashLang-Declaration "reader" "\"literal.rkt\"")
-              (string-length "#lang reader \"literal.rkt\"")
-              1))
+      (parse-header "#reader scribble/reader\n@title{demo}\n")
+      (Reader-Header "scribble/reader"
+                     (header-range "#reader scribble/reader")
+                     3))
     (check-equal?
-      (parse-prefix
-        "#lang reader (submod syntax/module-reader reader)\n1\n")
-      (prefix (WrapperHashLang-Declaration
-                "reader"
-                "(submod syntax/module-reader reader)")
-              (string-length
-                "#lang reader (submod syntax/module-reader reader)")
-              1))
-    (check-equal?
-      (parse-prefix "#lang reader (foo)\n1\n")
-      (prefix (WrapperHashLang-Declaration "reader" "(foo)")
-              (string-length "#lang reader (foo)")
-              1)))
+      (parse-header "#reader (reader demo)\nbody\n")
+      (Reader-Header "(reader demo)"
+                     (header-range "#reader (reader demo)")
+                     7)))
 
   (test-case
-    "parse-language-prefix recognizes #reader directives"
+    "parse-language-header recognizes raw modules"
     (check-equal?
-      (parse-prefix "#reader scribble/reader\n@title{demo}\n")
-      (prefix (Reader-Declaration "scribble/reader")
-              (string-length "#reader scribble/reader")
-              3))
+      (parse-header "(module demo typed/racket/base (define x 1))\n")
+      (Module-Header "typed/racket/base"
+                     (header-range "(module demo typed/racket/base")
+                     0))
     (check-equal?
-      (parse-prefix "#reader (reader demo)\nbody\n")
-      (prefix (Reader-Declaration "(reader demo)")
-              (string-length "#reader (reader demo)")
-              7)))
+      (parse-header "(module demo (lib \"racket/base\") (define x 1))\n")
+      (Module-Header "(lib \"racket/base\")"
+                     (header-range "(module demo (lib \"racket/base\")")
+                     0))
+    (check-equal?
+      (parse-header "(module demo \"literal.rkt\" (define x 1))\n")
+      (Module-Header "\"literal.rkt\""
+                     (header-range "(module demo \"literal.rkt\"")
+                     0)))
 
   (test-case
-    "parse-language-prefix recognizes raw modules"
+    "parse-language-header skips leading comments and sexp comments"
     (check-equal?
-      (parse-prefix "(module demo typed/racket/base (define x 1))\n")
-      (prefix (Module-Declaration "typed/racket/base")
-              (string-length "(module demo typed/racket/base")
-              0))
-    (check-equal?
-      (parse-prefix "(module demo (lib \"racket/base\") (define x 1))\n")
-      (prefix (Module-Declaration "(lib \"racket/base\")")
-              (string-length "(module demo (lib \"racket/base\")")
-              0))
-    (check-equal?
-      (parse-prefix "(module demo \"literal.rkt\" (define x 1))\n")
-      (prefix (Module-Declaration "\"literal.rkt\"")
-              (string-length "(module demo \"literal.rkt\"")
-              0)))
-
-  (test-case
-    "parse-language-prefix skips leading comments and sexp comments"
-    (check-equal?
-      (parse-prefix "; preamble\n#; (define ignored 1)\n#lang rhombus\nfun f(): 1\n")
-      (Language-Prefix (HashLang-Declaration "rhombus")
-                       33
-                       46
+      (parse-header "; preamble\n#; (define ignored 1)\n#lang rhombus\nfun f(): 1\n")
+      (HashLang-Header '("rhombus")
+                       (range 33 46)
                        13)))
 
   (test-case
-    "parse-language-prefix reports present but unrecognized selectors"
-    (check-equal? (parse-prefix "#lang \n(define x 1)\n")
-                  (prefix (HashLang-Declaration #f)
-                          (string-length "#lang ")
-                          1))
-    (check-equal? (parse-prefix "#lang reader\n(define x 1)\n")
-                  (prefix (HashLang-Declaration #f)
-                          (string-length "#lang reader\n(define x 1)")
-                          1))
-    (check-equal? (parse-prefix "#lang not-a-real-language\n1\n")
-                  (lang-prefix "not-a-real-language"
-                               (string-length "#lang not-a-real-language")
-                               1))
-    (check-equal? (parse-prefix "#reader\n")
-                  (prefix (Reader-Declaration #f)
-                          (string-length "#reader")
-                          2))
-    (check-equal? (parse-prefix "#reader does/not/exist\n")
-                  (prefix (Reader-Declaration "does/not/exist")
-                          (string-length "#reader does/not/exist")
-                          3))
-    (check-equal? (parse-prefix "(module demo does/not/exist (define x 1))\n")
-                  (prefix (Module-Declaration "does/not/exist")
-                          (string-length "(module demo does/not/exist")
-                          0))
-    (check-equal? (parse-prefix "(module demo 1 (define x 1))\n")
-                  (prefix (Module-Declaration "1")
-                          (string-length "(module demo 1")
-                          0))
-    (check-equal? (parse-prefix "(module demo)\n")
-                  (Language-Prefix
-                    (Module-Declaration #f)
-                    0
-                    (string-length "(module demo)")
-                    0))
-    (check-false (parse-prefix "(define x 1)\n(module demo racket/base x)\n")))
+    "parse-language-header reports missing and incomplete headers"
+    (check-equal? (parse-header "(define x 1)\n(module demo racket/base x)\n")
+                  (Missing-Header))
+    (check-equal? (parse-header "#lang \n(define x 1)\n")
+                  (Incomplete-Header 'hash-lang
+                                     (header-range "#lang ")
+                                     1))
+    (check-equal? (parse-header "#lang reader\n(define x 1)\n")
+                  (HashLangReader-Header "(define x 1)"
+                                         (range 0 (string-length "#lang reader\n(define x 1)"))
+                                         1))
+    (check-equal? (parse-header "#reader\n")
+                  (Incomplete-Header 'reader
+                                     (header-range "#reader")
+                                     2))
+    (check-equal? (parse-header "(module demo)\n")
+                  (Incomplete-Header 'module
+                                     (header-range "(module demo)")
+                                     0)))
 
   (test-case
-    "parse-language matches explicit known language families"
-    (check-equal? (language-name "#lang racket/base\n(define x 1)\n")
-                  'racket)
-    (check-equal? (language-name "#lang typed/racket/base\n(define x : Integer 1)\n")
-                  'typed/racket)
-    (for ([lang+name (in-list '(("scheme" scheme)
+    "source->language-policy matches explicit known language families"
+    (for ([lang+name (in-list '(("racket/base" racket)
+                                ("typed/racket/base" typed/racket)
                                 ("scheme/base" scheme)
-                                ("scheme/list" scheme)
                                 ("mzscheme" mzscheme)
                                 ("r5rs" r5rs)
                                 ("r6rs" r6rs)
@@ -203,109 +175,120 @@
                                 ("rosette" rosette)
                                 ("rosette/safe" rosette)
                                 ("pie" pie)))])
-      (check-equal? (language-name (format "#lang ~a\n1\n" (first lang+name)))
-                    (second lang+name)))
-    (check-equal? (language-name "#reader scribble/reader\n@title{demo}\n")
-                  'scribble)
-    (check-equal? (language-name "#lang rhombus\nfun f(): 1\n")
-                  'rhombus)
-    (check-equal? (language-name "#lang at-exp racket\n@(define x 1)\n")
-                  'at-exp)
-    (check-equal? (language-name "#lang s-exp racket/base\n1\n")
-                  's-exp)
-    (check-equal? (parse-known-language "#lang not-a-real-language\n1\n")
-                  'unrecognized-language)
-    (check-equal? (parse-known-language "#reader does/not/exist\n")
-                  'unrecognized-language)
-    (check-equal? (parse-known-language "(module demo does/not/exist 1)\n")
-                  'unrecognized-language))
+      (define actual
+        (Language-Policy-policy-language
+          (policy (format "#lang ~a\n1\n" (first lang+name)))))
+      (check-equal? actual (second lang+name))))
 
   (test-case
-    "find-language-by-text matches known families"
-    (check-equal? (Known-Language-name (find-language-by-text "racket/base"))
-                  'racket)
-    (check-equal? (Known-Language-name (find-language-by-text "typed/racket/base"))
-                  'typed/racket)
-    (check-equal? (Known-Language-name (find-language-by-text "scheme/base"))
-                  'scheme)
-    (check-equal? (Known-Language-name (find-language-by-text "r6rs"))
-                  'r6rs)
-    (check-equal? (Known-Language-name (find-language-by-text "htdp/isl+"))
-                  'htdp)
-    (check-equal? (Known-Language-name (find-language-by-text "rosette/safe"))
-                  'rosette)
-    (check-equal? (Known-Language-name (find-language-by-text "pie"))
-                  'pie)
-    (check-equal? (Known-Language-name (find-language-by-text "at-exp"))
-                  'at-exp)
-    (check-equal? (Known-Language-name (find-language-by-text "s-exp"))
-                  's-exp)
-    (check-false (find-language-by-text "plai/foo"))
-    (check-false (find-language-by-text "htdp/bsl/foo"))
-    (check-false (find-language-by-text "rosette/unsafe"))
-    (check-false (find-language-by-text "s-exp racket/base"))
-    (check-false (find-language-by-text "not-a-real-language")))
+    "source->language-policy applies selector policy"
+    (check-policy "#lang errortrace racket/base\n1\n"
+                  #:status 'complete
+                  #:language 'racket
+                  #:body-mode 'sexp
+                  #:format? #t
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang errortrace at-exp racket/base\n@(define x 1)\n"
+                  #:status 'complete
+                  #:language 'at-exp
+                  #:body-mode 'non-sexp
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang at-exp racket/base\n@(define x 1)\n"
+                  #:status 'complete
+                  #:language 'at-exp
+                  #:body-mode 'non-sexp
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang s-exp racket/base\n(define x 1)\n"
+                  #:status 'complete
+                  #:language 's-exp
+                  #:body-mode 'sexp
+                  #:format? #t
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#reader scribble/reader\n@title{demo}\n"
+                  #:status 'complete
+                  #:language 'scribble
+                  #:body-mode 'non-sexp
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang reader syntax/module-reader\nracket/base\n"
+                  #:status 'complete
+                  #:language 'unrecognized-language
+                  #:body-mode 'unknown
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "(module demo typed/racket/base (define x 1))\n"
+                  #:status 'complete
+                  #:language 'typed/racket
+                  #:body-mode 'sexp
+                  #:format? #t
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang not-a-real-language\n1\n"
+                  #:uri "file:///tmp/demo.rhm"
+                  #:status 'complete
+                  #:language 'unrecognized-language
+                  #:body-mode 'unknown
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "#lang \n1\n"
+                  #:status 'incomplete
+                  #:language #f
+                  #:body-mode 'unknown
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t))
 
   (test-case
-    "parse-language can fall back to distinctive suffixes"
-    (check-equal? (language-name "fun f(): 1\n" "file:///tmp/demo.rhm")
-                  'rhombus)
-    (check-equal? (language-name "@title{demo}\n" "file:///tmp/demo.scrbl")
-                  'scribble)
-    (check-false (language-name "(define x 1)\n" "file:///tmp/demo.rkt"))
-    (check-equal? (parse-known-language "#lang not-a-real-language\n1\n"
-                                        "file:///tmp/demo.rhm")
-                  'unrecognized-language))
+    "source->language-policy falls back by suffix only for missing headers"
+    (check-policy "fun f(): 1\n"
+                  #:uri "file:///tmp/demo.rhm"
+                  #:status 'missing
+                  #:language 'rhombus
+                  #:body-mode 'non-sexp
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "@title{demo}\n"
+                  #:uri "file:///tmp/demo.scrbl"
+                  #:status 'missing
+                  #:language 'scribble
+                  #:body-mode 'non-sexp
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "(define x 1)\n"
+                  #:uri "file:///tmp/demo.rkt"
+                  #:status 'missing
+                  #:language #f
+                  #:body-mode 'unknown
+                  #:format? #f
+                  #:require-header? #t
+                  #:expand? #t))
 
   (test-case
-    "guess-language-by-uri only uses distinctive suffixes"
-    (check-equal? (Known-Language-name (guess-language-by-uri "file:///tmp/demo.rhm"))
-                  'rhombus)
-    (check-equal? (Known-Language-name (guess-language-by-uri "file:///tmp/demo.scrbl"))
-                  'scribble)
-    (check-false (guess-language-by-uri "file:///tmp/demo.rkt")))
-
-  (test-case
-    "wrapped #lang lines classify wrapper languages and body mode"
-    (define at-exp-info (language-info "#lang at-exp racket\n@(define x 1)\n"))
-    (check-equal? (Known-Language-name (Language-Info-language at-exp-info))
-                  'at-exp)
-    (check-equal? (Language-Info-body-mode at-exp-info) 'non-sexp)
-
-    (define s-exp-info (language-info "#lang s-exp racket/base\n(define x 1)\n"))
-    (check-equal? (Known-Language-name (Language-Info-language s-exp-info))
-                  's-exp)
-    (check-equal? (Language-Info-body-mode s-exp-info) 'sexp))
-
-  (test-case
-    "rktd files are Racket data, not expandable modules"
-    (define path (string->path "/tmp/demo.rktd"))
-    (check-true (racket-data-file-path? path))
-    (check-false (requires-expansion? path))
-    (check-false (requires-language-declaration? path)))
-
-  (test-case
-    "rkt files still require module policy"
-    (define path (string->path "/tmp/demo.rkt"))
-    (check-false (racket-data-file-path? path))
-    (check-true (requires-expansion? path))
-    (check-true (requires-language-declaration? path)))
-
-  (test-case
-    "sexp-language? is true only for known sexp families"
-    (check-true (sexp-language? "#lang racket/base\n(define x 1)\n"))
-    (check-true (sexp-language? "(module demo typed/racket/base (define x 1))\n"))
-    (check-true (sexp-language? "#lang scheme/base\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang r5rs\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang r6rs\n(import (rnrs))\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang r7rs\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang lazy\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang htdp/isl+\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang rosette\n(define x 1)\n"))
-    (check-true (sexp-language? "#lang pie\n(claim n Nat)\n"))
-    (check-true (sexp-language? "#lang s-exp racket/base\n(define x 1)\n"))
-    (check-false (sexp-language? "#lang plai/foo\n(define x 1)\n"))
-    (check-false (sexp-language? "#lang at-exp racket\n@(define x 1)\n"))
-    (check-false (sexp-language? "#lang scribble/manual\n@title{demo}\n"))
-    (check-false (sexp-language? "fun f(): 1\n" "file:///tmp/demo.rhm"))
-    (check-false (sexp-language? "(define x 1)\n" "file:///tmp/demo.rkt"))))
+    "rktd files keep data-file policy"
+    (check-policy "#lang racket/base\n1\n"
+                  #:uri "file:///tmp/demo.rktd"
+                  #:status 'complete
+                  #:language 'racket
+                  #:body-mode 'sexp
+                  #:format? #t
+                  #:require-header? #t
+                  #:expand? #t)
+    (check-policy "(define x 1)\n"
+                  #:uri "file:///tmp/demo.rktd"
+                  #:status 'missing
+                  #:language 'racket-data
+                  #:body-mode 'unknown
+                  #:format? #f
+                  #:require-header? #f
+                  #:expand? #f)))

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -7,6 +7,7 @@
            "../../doclib/check-syntax.rkt"
            "../../doclib/editor.rkt"
            "../../doclib/internal-types.rkt"
+           "../../doclib/lexer.rkt"
            "../../common/interfaces.rkt"
            racket/class
            racket/file
@@ -380,18 +381,19 @@
                 #:when (string=? (Diagnostic-message diag) expected-message))
       diag))
 
-  (define (language-declaration-diagnostics diags)
+  (define (language-header-diagnostics diags)
     (for/list ([diag (in-list diags)]
-               #:when (string=? (Diagnostic-source diag) "Language Declaration Check"))
+               #:when (string=? (Diagnostic-source diag) "Language Header Check"))
       diag))
 
   (define (check-syntax-diagnostics uri text)
     (define doc-text (new lsp-editor%))
     (send doc-text insert text 0)
-    (set->list (send (CSResult-trace (check-syntax uri doc-text)) get-warn-diags)))
+    (define lexer-state (build-lexer-state text uri))
+    (set->list (send (CSResult-trace (check-syntax uri doc-text lexer-state)) get-warn-diags)))
 
   (test-case
-    "Document diagnostics report missing language declarations"
+    "Document diagnostics report missing language headers"
     (define text "(define x 1)\n")
     (define diags
       (check-syntax-diagnostics "file:///tmp/missing-language-test.rkt"
@@ -401,7 +403,7 @@
         diags
         "Missing language header. Start the file with `#lang <language>`, `#reader <reader>`, or `(module <name> <language> ...)`."))
     (check-not-false diag)
-    (check-equal? (Diagnostic-source diag) "Language Declaration Check")
+    (check-equal? (Diagnostic-source diag) "Language Header Check")
     (define range (Diagnostic-range diag))
     (check-equal? (Pos-line (Range-start range)) 0)
     (check-equal? (Pos-char (Range-start range)) 0)
@@ -415,7 +417,7 @@
     (define diags
       (check-syntax-diagnostics "file:///tmp/unknown-language-test.rkt"
                                 text))
-    (check-equal? (language-declaration-diagnostics diags) '()))
+    (check-equal? (language-header-diagnostics diags) '()))
 
   (test-case
     "Document diagnostics simplify missing collection messages"
@@ -465,16 +467,16 @@
     (check-equal? (Diagnostic-source diag) "Racket"))
 
   (test-case
-    "Document diagnostics accept wrapped #lang declarations"
+    "Document diagnostics accept wrapped #lang headers"
     (define at-exp-diags
       (check-syntax-diagnostics "file:///tmp/at-exp-language-test.rkt"
                                 "#lang at-exp racket\n@(+ 1 2)\n"))
-    (check-equal? (language-declaration-diagnostics at-exp-diags) '())
+    (check-equal? (language-header-diagnostics at-exp-diags) '())
 
     (define s-exp-diags
       (check-syntax-diagnostics "file:///tmp/s-exp-language-test.rkt"
                                 "#lang s-exp racket/base\n(+ 1 2)\n"))
-    (check-equal? (language-declaration-diagnostics s-exp-diags) '()))
+    (check-equal? (language-header-diagnostics s-exp-diags) '()))
 
   (test-case
     "Document diagnostics use first line range for empty language spans"
@@ -487,7 +489,7 @@
         diags
         "Incomplete language header. Provide the missing language or reader name."))
     (check-not-false diag)
-    (check-equal? (Diagnostic-source diag) "Language Declaration Check")
+    (check-equal? (Diagnostic-source diag) "Language Header Check")
     (define range (Diagnostic-range diag))
     (check-equal? (Pos-line (Range-start range)) 0)
     (check-equal? (Pos-char (Range-start range)) 0)
@@ -594,7 +596,8 @@ END
     (define test-trace%
       (class build-trace%
         (super-new [src (string->path "/tmp/completion-prefix-test.rkt")]
-                   [doc-text (new lsp-editor%)])
+                   [doc-text (new lsp-editor%)]
+                   [lexer-state (build-lexer-state text uri)])
         (define/override (get-completions) '())
         (define/override (get-online-completions str-before-cursor)
           (hash-ref prefix->completions str-before-cursor '()))))

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -418,6 +418,36 @@
     (check-equal? (language-declaration-diagnostics diags) '()))
 
   (test-case
+    "Document diagnostics simplify missing collection messages"
+    (define text "#lang racke\n")
+    (define diags
+      (check-syntax-diagnostics "file:///tmp/missing-collection-test.rkt"
+                                text))
+    (define diag
+      (find-diagnostic-by-message
+        diags
+        (string-append
+          "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\n"
+          "Check that the module name is correct and the package is installed.")))
+    (check-not-false diag)
+    (check-equal? (Diagnostic-source diag) "Racket"))
+
+  (test-case
+    "Document diagnostics do not label requires as #lang failures"
+    (define text "#lang racket/base\n(require racke/lang/reader)\n")
+    (define diags
+      (check-syntax-diagnostics "file:///tmp/missing-require-collection-test.rkt"
+                                text))
+    (define diag
+      (find-diagnostic-by-message
+        diags
+        (string-append
+          "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\n"
+          "Check that the module name is correct and the package is installed.")))
+    (check-not-false diag)
+    (check-equal? (Diagnostic-source diag) "Racket"))
+
+  (test-case
     "Document diagnostics accept wrapped #lang declarations"
     (define at-exp-diags
       (check-syntax-diagnostics "file:///tmp/at-exp-language-test.rkt"

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -380,6 +380,11 @@
                 #:when (string=? (Diagnostic-message diag) expected-message))
       diag))
 
+  (define (language-declaration-diagnostics diags)
+    (for/list ([diag (in-list diags)]
+               #:when (string=? (Diagnostic-source diag) "Language Declaration Check"))
+      diag))
+
   (define (check-syntax-diagnostics uri text)
     (define doc-text (new lsp-editor%))
     (send doc-text insert text 0)
@@ -394,7 +399,7 @@
     (define diag
       (find-diagnostic-by-message
         diags
-        "Missing language declaration. Add a `#lang` line, `#reader`, or `(module ... <language> ...)` form."))
+        "Missing language header. Start the file with `#lang <language>`, `#reader <reader>`, or `(module <name> <language> ...)`."))
     (check-not-false diag)
     (check-equal? (Diagnostic-source diag) "Language Declaration Check")
     (define range (Diagnostic-range diag))
@@ -405,23 +410,24 @@
                   (string-length "(define x 1)")))
 
   (test-case
-    "Document diagnostics report unrecognized language declarations"
+    "Document diagnostics accept unknown language headers"
     (define text "#lang not-a-real-language\n1\n")
     (define diags
-      (check-syntax-diagnostics "file:///tmp/unrecognized-language-test.rkt"
+      (check-syntax-diagnostics "file:///tmp/unknown-language-test.rkt"
                                 text))
-    (define diag
-      (find-diagnostic-by-message
-        diags
-        "Unrecognized language declaration `not-a-real-language`. Check the language name or reader path."))
-    (check-not-false diag)
-    (check-equal? (Diagnostic-source diag) "Language Declaration Check")
-    (define range (Diagnostic-range diag))
-    (check-equal? (Pos-line (Range-start range)) 0)
-    (check-equal? (Pos-char (Range-start range)) 0)
-    (check-equal? (Pos-line (Range-end range)) 0)
-    (check-equal? (Pos-char (Range-end range))
-                  (string-length "#lang not-a-real-language")))
+    (check-equal? (language-declaration-diagnostics diags) '()))
+
+  (test-case
+    "Document diagnostics accept wrapped #lang declarations"
+    (define at-exp-diags
+      (check-syntax-diagnostics "file:///tmp/at-exp-language-test.rkt"
+                                "#lang at-exp racket\n@(+ 1 2)\n"))
+    (check-equal? (language-declaration-diagnostics at-exp-diags) '())
+
+    (define s-exp-diags
+      (check-syntax-diagnostics "file:///tmp/s-exp-language-test.rkt"
+                                "#lang s-exp racket/base\n(+ 1 2)\n"))
+    (check-equal? (language-declaration-diagnostics s-exp-diags) '()))
 
   (test-case
     "Document diagnostics use first line range for empty language spans"
@@ -432,7 +438,7 @@
     (define diag
       (find-diagnostic-by-message
         diags
-        "Unrecognized language declaration. Check the language name after `#lang`, `#reader`, or in `(module ... <language> ...)`."))
+        "Incomplete language header. Provide the missing language or reader name."))
     (check-not-false diag)
     (check-equal? (Diagnostic-source diag) "Language Declaration Check")
     (define range (Diagnostic-range diag))

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -427,8 +427,9 @@
       (find-diagnostic-by-message
         diags
         (string-append
-          "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\n"
-          "Check that the module name is correct and the package is installed.")))
+          "Cannot find language \"racke\".\n"
+          "  module path: racke/lang/reader\n"
+          "Check that the language name is correct and the package is installed.")))
     (check-not-false diag)
     (check-equal? (Diagnostic-source diag) "Racket"))
 
@@ -442,7 +443,23 @@
       (find-diagnostic-by-message
         diags
         (string-append
-          "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\n"
+          "Cannot find language \"racke\".\n"
+          "  module path: racke/lang/reader\n"
+          "Check that the language name is correct and the package is installed.")))
+    (check-not-false diag)
+    (check-equal? (Diagnostic-source diag) "Racket"))
+
+  (test-case
+    "Document diagnostics report missing require modules"
+    (define text "#lang racket/base\n(require foo/bar)\n")
+    (define diags
+      (check-syntax-diagnostics "file:///tmp/missing-require-module-test.rkt"
+                                text))
+    (define diag
+      (find-diagnostic-by-message
+        diags
+        (string-append
+          "Cannot find module \"foo/bar\" in collection \"foo\".\n"
           "Check that the module name is correct and the package is installed.")))
     (check-not-false diag)
     (check-equal? (Diagnostic-source diag) "Racket"))

--- a/tests/lib/lexer-test.rkt
+++ b/tests/lib/lexer-test.rkt
@@ -357,9 +357,9 @@
     "unknown-language body mode is unknown"
     (define text "#lang not-a-real-language\n(define x 1)\n")
     (define snapshot (build-lexer-snapshot text))
-    (define info (lexer-language-info (LexerSnapshot-text snapshot)
-                                      (LexerSnapshot-tokens snapshot)))
-    (check-equal? (Language-Info-body-mode info) 'unknown))
+    (define policy (lexer-language-policy (LexerSnapshot-text snapshot)
+                                          (LexerSnapshot-tokens snapshot)))
+    (check-equal? (Language-Policy-body-mode policy) 'unknown))
 
   (test-case
     "unknown-language still builds a forest for editor affordances"
@@ -372,18 +372,18 @@
       '()))
 
   (test-case
-    "unknown #reader and raw modules also produce unknown language info"
+    "unknown #reader and raw modules also produce unknown language policy"
     (define reader-text "#reader does/not/exist\nbody\n")
     (define reader-snapshot (build-lexer-snapshot reader-text))
-    (define reader-info (lexer-language-info (LexerSnapshot-text reader-snapshot)
-                                             (LexerSnapshot-tokens reader-snapshot)))
-    (check-equal? (Language-Info-body-mode reader-info) 'unknown)
+    (define reader-policy (lexer-language-policy (LexerSnapshot-text reader-snapshot)
+                                                 (LexerSnapshot-tokens reader-snapshot)))
+    (check-equal? (Language-Policy-body-mode reader-policy) 'unknown)
 
     (define module-text "(module demo does/not/exist (define x 1))\n")
     (define module-snapshot (build-lexer-snapshot module-text))
-    (define module-info (lexer-language-info (LexerSnapshot-text module-snapshot)
-                                             (LexerSnapshot-tokens module-snapshot)))
-    (check-equal? (Language-Info-body-mode module-info) 'unknown))
+    (define module-policy (lexer-language-policy (LexerSnapshot-text module-snapshot)
+                                                 (LexerSnapshot-tokens module-snapshot)))
+    (check-equal? (Language-Policy-body-mode module-policy) 'unknown))
 
   (test-case
     "lexer snapshot position queries return token and symbol entries"

--- a/tests/sync/diagnostics.json
+++ b/tests/sync/diagnostics.json
@@ -11,5 +11,5 @@
     },
     "severity": 1,
     "source": "Language Declaration Check",
-    "message": "Unrecognized language declaration `racke`. Check the language name or reader path."
+    "message": "Invalid language header `racke`. Check the language name or reader path."
 }

--- a/tests/sync/diagnostics.json
+++ b/tests/sync/diagnostics.json
@@ -11,5 +11,5 @@
     },
     "severity": 1,
     "source": "Racket",
-    "message": "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\nCheck that the module name is correct and the package is installed."
+    "message": "Cannot find language \"racke\".\n  module path: racke/lang/reader\nCheck that the language name is correct and the package is installed."
 }

--- a/tests/sync/diagnostics.json
+++ b/tests/sync/diagnostics.json
@@ -10,6 +10,6 @@
         }
     },
     "severity": 1,
-    "source": "Language Declaration Check",
-    "message": "Invalid language header `racke`. Check the language name or reader path."
+    "source": "Racket",
+    "message": "Cannot find module \"racke/lang/reader\" in collection \"racke/lang\".\nCheck that the module name is correct and the package is installed."
 }

--- a/tests/sync/test.rkt
+++ b/tests/sync/test.rkt
@@ -2,15 +2,10 @@
 
 (module+ test
   (require rackunit
+           json
+           racket/port
            "../client.rkt"
            "../../common/json-util.rkt")
-
-  (define (has-racket-collection-not-found-diagnostic? notification)
-    (for/or ([diagnostic (in-list (jsexpr-ref notification '(params diagnostics)))])
-      (and (equal? "Racket" (jsexpr-ref diagnostic '(source)))
-           (regexp-match?
-             #rx"^standard-module-name-resolver: collection not found"
-             (jsexpr-ref diagnostic '(message))))))
 
   (with-racket-lsp
     (λ (lsp)
@@ -28,7 +23,9 @@
       (let ([resp (client-wait-notification lsp)])
         (check-true (jsexpr-has-key? resp '(params diagnostics)))
         (check-false (null? (jsexpr-ref resp '(params diagnostics))))
-        (check-true (has-racket-collection-not-found-diagnostic? resp)))
+        (check-true
+          (client-has-diagnostic? resp
+                                  (read-json (open-input-file "diagnostics.json")))))
 
 
       (define didchange-req
@@ -51,4 +48,3 @@
                            (hasheq 'textDocument
                                    (hasheq 'uri "file:///test.rkt"))))
       (client-send lsp didclose-req))))
-

--- a/tests/sync/test.rkt
+++ b/tests/sync/test.rkt
@@ -48,3 +48,4 @@
                            (hasheq 'textDocument
                                    (hasheq 'uri "file:///test.rkt"))))
       (client-send lsp didclose-req))))
+

--- a/tests/sync/test.rkt
+++ b/tests/sync/test.rkt
@@ -2,10 +2,15 @@
 
 (module+ test
   (require rackunit
-           json
-           racket/port
            "../client.rkt"
            "../../common/json-util.rkt")
+
+  (define (has-racket-collection-not-found-diagnostic? notification)
+    (for/or ([diagnostic (in-list (jsexpr-ref notification '(params diagnostics)))])
+      (and (equal? "Racket" (jsexpr-ref diagnostic '(source)))
+           (regexp-match?
+             #rx"^standard-module-name-resolver: collection not found"
+             (jsexpr-ref diagnostic '(message))))))
 
   (with-racket-lsp
     (λ (lsp)
@@ -23,9 +28,7 @@
       (let ([resp (client-wait-notification lsp)])
         (check-true (jsexpr-has-key? resp '(params diagnostics)))
         (check-false (null? (jsexpr-ref resp '(params diagnostics))))
-        (check-true
-          (client-has-diagnostic? resp
-                                  (read-json (open-input-file "diagnostics.json")))))
+        (check-true (has-racket-collection-not-found-diagnostic? resp)))
 
 
       (define didchange-req


### PR DESCRIPTION
Solve #216

I did a redesign for language header parsing and diagnostics header check.

Now doc-lang.rkt use a unified terms: parse header and language policy. It has two clean stages:

1. parse the header into a `Language-Header` record.
2. Match it against a predefined `language-specs` list that produces a `Language-Policy` struct that will be used by diagnostics, formatting, expansion, etc.

`rktd` now inside the predefined list define its policy for features, and no need special logic.

I also pass `lexer-state` (that includes `Language-Policy` data) to check-syntax, and services. So they don't need to run lexer again.

Language Header Check in diagnostics module only checks

- language header is missing, or
- malformed language header: header exists, but cannot parse a language name

It does not detect any other issues.

I also improved "collection not found" diagnostics messages that come from reader and expander:

```racket
#lang racke
```

now has this message:

```
Cannot find language "racke".
  module path: racke/lang/reader
Check that the language name is correct and the package is installed.
```

And

```racket
(require foo/bar)
```

now has this message:

```
Cannot find module "foo/bar" in collection "foo".
Check that the module name is correct and the package is installed.
```
