### PR TITLE
Improve json type DSL and allow recursive types

### DIFF
--- a/common/interfaces.rkt
+++ b/common/interfaces.rkt
@@ -82,7 +82,7 @@
   [newText string?])
 
 (define-json-struct WorkspaceEdit
-  [changes (hash/c symbol? (listof TextEdit))])
+  [changes (hashof symbol? (listof TextEdit))])
 
 (define-json-enum DiagnosticSeverity
   [Error 1]
@@ -159,15 +159,14 @@
   [location Location])
 
 ;; Hierarchical document symbol. `range` covers the whole form (including its
-;; body) while `selectionRange` only covers the name. `children` is a list of
-;; DocumentSymbol, typed as list? because define-json-struct cannot express
-;; self-referential field types; encoding still recurses via ->jsexpr.
+;; body) while `selectionRange` only covers the name. `children` recursively
+;; contains nested document symbols.
 (define-json-struct DocumentSymbol
   [name string?]
   [kind SymbolKind]
   [range Range]
   [selectionRange Range]
-  [children list?])
+  [children (listof DocumentSymbol)])
 
 (define-json-struct Hover
   [contents string?]
@@ -258,12 +257,12 @@
   (and (integer? x) (<= 0 x uinteger-upper-limit)))
 
 (define-json-struct FormattingOptions
-  [tab-size uinteger? #:json tabSize]
+  [tab-size (contract uinteger?) #:json tabSize]
   [insert-spaces boolean? #:json insertSpaces]
   [trim-trailing-whitespace (optional boolean?) #:json trimTrailingWhitespace]
   [insert-final-newline (optional boolean?) #:json insertFinalNewline]
   [trim-final-newlines (optional boolean?) #:json trimFinalNewlines]
-  [key (or/c false/c (optional/c hash?))])
+  [key (contract (or/c false/c (optional/c hash?)))])
 
 ;; Character-offset range. Distinct from the protocol-level `Range`
 ;; (which uses line/char positions); this one uses zero-based absolute

--- a/common/json-util.rkt
+++ b/common/json-util.rkt
@@ -1,12 +1,10 @@
 #lang racket/base
 (require (for-syntax racket/base
                      racket/list
-                     racket/match
                      racket/set
                      racket/syntax
                      syntax/parse
-                     racket/provide-transform
-                     racket/bool)
+                     racket/provide-transform)
          json
          racket/generic
          racket/match
@@ -95,15 +93,18 @@
 ;;
 ;; Used in struct field declarations and union variant lists.
 ;;
-;;   identifier          decodable type if jsexpr->T is bound; otherwise contract
+;;   string? / boolean? / number? / exact-integer? /
+;;   exact-nonnegative-integer? / symbol?
+;;                       builtin contract shorthands; decode as identity
+;;   (contract C)        arbitrary Racket contract/predicate; decode as identity
+;;   identifier          JSON type; uses T?, T-js?, and jsexpr->T lazily
 ;;   (listof T)          homogeneous list, each element decoded via T
 ;;   (optional T)        T | Nothing; omitted JSON keys map to Nothing
-;;   (hash/c K V)        hash map, K and V are type-specs (see above)
-;;   (or/c T1 T2 ...)    first successful decode wins
-;;   <expr>              arbitrary contract/predicate expression
+;;   (hashof K V)        hash map, K and V are type-specs (see above)
+;;   (union T1 T2 ...)   first successful decode wins, in order
 ;;
-;; When an identifier Name has a jsexpr->Name decoder in scope, the macro
-;; uses it for recursive decoding and picks Name? as the runtime contract.
+;; Bare non-builtin identifiers always name JSON domain types. Use
+;; `(contract ...)` for project-local predicates or raw Racket contracts.
 ;;
 ;; ----------------------------------------------------------------------------
 ;; 3. Generated bindings
@@ -211,10 +212,6 @@
   (define (symbol->keyword sym)
     (string->keyword (symbol->string sym)))
 
-  (define (id-bound? id)
-    (and (identifier? id)
-         (not (false? (identifier-binding id)))))
-
   (define ((name-id fmt) name-stx)
     (format-id name-stx fmt name-stx))
 
@@ -236,53 +233,67 @@
   (define json-struct-accessor-id (name+field-id "~a~~-~a"))
   (define json-public-accessor-id (name+field-id "~a-~a"))
 
-  (define (decodable-type-id? id)
-    (id-bound? (name->decoder-id id)))
+  (define builtin-contract-ids
+    '(string?
+       boolean?
+       number?
+       exact-integer?
+       exact-nonnegative-integer?
+       symbol?))
 
-  (define (type-id-ctc id)
-    (match* ((decodable-type-id? id)
-             (id-bound? (name->pred-id id)))
-      [(#t #t) (name->pred-id id)]
-      ;; Decodable types must provide a runtime predicate.
-      [(#t #f)
-       (raise-syntax-error
-         'type-spec
-         (format "decodable type ~a is missing a runtime predicate ~a"
-                 (syntax->datum id)
-                 (name->pred-id id))
-         id)]
-      ;; Non-decodable ids are usually contracts/predicates.
-      [(#f _) id]))
+  (define (builtin-contract-id? id)
+    (and (identifier? id)
+         (memq (syntax-e id) builtin-contract-ids)))
 
-  (define (type-id-decoder id)
-    (if (decodable-type-id? id)
-        (name->decoder-id id)
-        #'values))
+  (define (quote-datum stx)
+    #`'#,(syntax->datum stx))
 
-  (define (type-id-json-predicate id)
-    (match* ((decodable-type-id? id)
-             (id-bound? (name->js-pred-id id)))
-      [(#t #t) (name->js-pred-id id)]
-      ;; Missing JSON predicate but provided a decoder: skip JSON validation.
-      [(#t #f) #'(lambda (_) #t)]
-      [(#f _) id]))
+  (define (json-type-ctc id)
+    #`(lambda (x)
+        (#,(name->pred-id id) x)))
+
+  (define (json-type-decoder id)
+    #`(lambda (x)
+        (#,(name->decoder-id id) x)))
+
+  (define (json-type-predicate id)
+    #`(lambda (x)
+        (#,(name->js-pred-id id) x)))
 
   ;; type-spec normalizes the DSL type annotation into four compile-time
   ;; attributes used by define-json-struct expansion:
   ;; - ctc: contract for the generated struct field
   ;; - decoder: function to decode JSON values into Racket values
   ;; - json-pred: predicate used by the generated `*-js?` validator
+  ;; - label: quoted type-spec datum used in decoder error messages
   ;; - optional?: whether the field can be omitted (for optional ...)
   (define-syntax-class type-spec
-    #:attributes (ctc decoder json-pred optional?)
-    #:datum-literals (listof optional hash/c or/c)
-    ;; Bare identifier type. If a matching decoder exists (jsexpr->T),
-    ;; treat it as a decodable domain type; otherwise use the identifier
-    ;; directly and leave decoding as identity.
+    #:attributes (ctc decoder json-pred label optional?)
+    #:datum-literals (contract listof optional hashof union)
+    ;; Builtin primitive contracts are shorthands for `(contract ...)`. Keep the
+    ;; allowlist small so project-local predicates remain explicit.
     (pattern tid:id
-             #:with ctc (type-id-ctc #'tid)
-             #:with decoder (type-id-decoder #'tid)
-             #:with json-pred (type-id-json-predicate #'tid)
+             #:when (builtin-contract-id? #'tid)
+             #:with ctc #'tid
+             #:with decoder #'values
+             #:with json-pred #'tid
+             #:with label (quote-datum #'tid)
+             #:attr optional? #f)
+    ;; Bare non-builtin identifiers are JSON domain types. References are lazy
+    ;; so a type can name itself in its own field specs.
+    (pattern tid:id
+             #:with ctc (json-type-ctc #'tid)
+             #:with decoder (json-type-decoder #'tid)
+             #:with json-pred (json-type-predicate #'tid)
+             #:with label (quote-datum #'tid)
+             #:attr optional? #f)
+    ;; Explicit escape hatch for Racket predicates/contracts. It does not perform
+    ;; JSON type decoding; the value is checked and passed through.
+    (pattern (contract ctc-expr:expr)
+             #:with ctc #'ctc-expr
+             #:with decoder #'values
+             #:with json-pred #'ctc-expr
+             #:with label (quote-datum #'(contract ctc-expr))
              #:attr optional? #f)
     ;; Homogeneous lists recursively decode/validate each element.
     (pattern (listof elem:type-spec)
@@ -291,6 +302,7 @@
              #:with json-pred #'(lambda (xs)
                                   (and (list? xs)
                                        (andmap elem.json-pred xs)))
+             #:with label (quote-datum #'(listof elem))
              #:attr optional? #f)
     ;; Optional values propagate Nothing unchanged and decode present values.
     (pattern (optional elem:type-spec)
@@ -300,31 +312,29 @@
                                     x
                                     (elem.decoder x)))
              #:with json-pred #'(optional/c elem.json-pred)
+             #:with label (quote-datum #'(optional elem))
              #:attr optional? #t)
-    (pattern (hash/c key:type-spec val:type-spec)
+    (pattern (hashof key:type-spec val:type-spec)
              #:with ctc #'(hash/c key.ctc val.ctc)
              #:with decoder #'(lambda (h)
-                                (for/hasheq ([(k v) h])
-                                  (values (key.decoder k)
-                                          (val.decoder v))))
+                                (for/hasheq ([(k v) (in-hash h)])
+                                  (values (key.decoder k) (val.decoder v))))
              #:with json-pred #'(hash/c key.json-pred val.json-pred)
+             #:with label (quote-datum #'(hashof key val))
              #:attr optional? #f)
-    (pattern (or/c opt:type-spec ...+)
+    (pattern (union opt:type-spec ...+)
              #:with ctc #'(or/c opt.ctc ...)
+             #:with json-pred #'(or/c opt.json-pred ...)
+             #:with label (quote-datum #'(union opt ...))
              #:with decoder #'(lambda (x)
                                 (let/ec return
-                                  (with-handlers ([exn:fail? void])
-                                    (define decoded (opt.decoder x))
-                                    (when (opt.ctc decoded)
-                                      (return decoded)))
+                                  (when (opt.json-pred x)
+                                    (return (opt.decoder x)))
                                   ...
-                                  (error 'or/c "no variant matched value: ~v" x)))
-             #:with json-pred #'(or/c opt.json-pred ...)
-             #:attr optional? #f)
-    (pattern other:expr
-             #:with ctc #'other
-             #:with decoder #'values
-             #:with json-pred #'other
+                                  (error 'union
+                                         "no union alternative matched value: ~v\nexpected: ~v"
+                                         x
+                                         label)))
              #:attr optional? #f))
 
   ;; Syntax class to parse a field clause.
@@ -332,19 +342,21 @@
   ;;   - [field type-spec]            -> json key is same as field name
   ;;   - [field type-spec #:json key] -> custom json key
   (define-syntax-class json-struct-clause
-    #:attributes (field type-pred type-decoder type-json-pred optional? json-key keyword)
+    #:attributes (field type-pred type-decoder type-json-pred type-label optional? json-key keyword)
     (pattern [field:id ts:type-spec]
              #:with json-key #'field
              #:with keyword (symbol->keyword (syntax-e #'field))
              #:with type-pred #'ts.ctc
              #:with type-decoder #'ts.decoder
              #:with type-json-pred #'ts.json-pred
+             #:with type-label #'ts.label
              #:attr optional? (attribute ts.optional?))
     (pattern [field:id ts:type-spec #:json json-key:id]
              #:with keyword (symbol->keyword (syntax-e #'field))
              #:with type-pred #'ts.ctc
              #:with type-decoder #'ts.decoder
              #:with type-json-pred #'ts.json-pred
+             #:with type-label #'ts.label
              #:attr optional? (attribute ts.optional?)))
 
   (define (any-keyword? stx)
@@ -404,21 +416,37 @@
                ...))))
 
   ;; Generates jsexpr->Name decoder.
-  (define (gen-json-decoder stx decoder-name keyword-constructor-id json-keys keywords decoders)
+  (define (gen-json-decoder stx decoder-name name keyword-constructor-id json-keys keywords fields decoders labels)
     (define input-id (datum->syntax stx 'js))
+    (define decoder-symbol-expr (quote-datum decoder-name))
     (define field-values
       (for/list ([jk json-keys]
-                 [dec decoders])
+                 [fld fields]
+                 [dec decoders]
+                 [label labels])
         #`(let ([v (hash-ref #,input-id '#,jk (Nothing))])
-            (if (Nothing? v) v (#,dec v)))))
+            (if (Nothing? v)
+                v
+                (with-handlers ([exn:fail?
+                                 (lambda (e)
+                                   (raise-arguments-error
+                                     #,decoder-symbol-expr
+                                     "failed to decode field"
+                                     "type" '#,name
+                                     "field" '#,fld
+                                     "expected" #,label
+                                     "value" v
+                                     "cause" (exn-message e)))])
+                  (#,dec v))))))
     (with-syntax ([decoder-name decoder-name]
+                  [decoder-symbol (quote-datum decoder-name)]
                   [input input-id]
                   [keyword-constructor keyword-constructor-id]
                   [(kw ...) keywords]
                   [(fv ...) field-values])
       #'(define (decoder-name input)
           (unless (hash? input)
-            (error 'decoder-name "expected hash, got ~v" input))
+            (error decoder-symbol "expected hash, got ~v" input))
           (keyword-constructor (~@ kw fv) ...))))
 
   ;; Generates as-Name / ^Name match expanders and helper decoder wrapper.
@@ -587,6 +615,7 @@
      (define fields (syntax->list #'(clause.field ...)))
      (define contracts (syntax->list #'(clause.type-pred ...)))
      (define decoders (syntax->list #'(clause.type-decoder ...)))
+     (define labels (syntax->list #'(clause.type-label ...)))
      (define json-preds (syntax->list #'(clause.type-json-pred ...)))
      (define optional-flags (attribute clause.optional?))
      (define json-keys (syntax->list #'(clause.json-key ...)))
@@ -623,7 +652,7 @@
           ,(gen-struct-match-expander stx #'name iname keyword-constructor-id keywords fields json-keys)
           ,(gen-json-match-expander stx name-js keywords fields json-keys)
           ,(gen-json-predicate stx name-js-pred json-keys json-preds optional-flags)
-          ,(gen-json-decoder stx decoder-name keyword-constructor-id json-keys keywords decoders)
+          ,(gen-json-decoder stx decoder-name #'name keyword-constructor-id json-keys keywords fields decoders labels)
           ,(gen-as-match-expanders stx as-name decode-name try-decoder decoder-name #'name)
 
           ,(gen-exports name-exports #'name pred public-accessors name-js name-js-pred decoder-name as-name decode-name))
@@ -732,9 +761,9 @@
      (define decode-name (name->decode-match-id #'name))
      (define try-decoder (name->try-decoder-id #'name))
 
-     ;; Collapse the union variants into one `(or/c ...)` type-spec and reuse
+     ;; Collapse the union variants into one `(union ...)` type-spec and reuse
      ;; its normalized predicate/decoder/json-predicate attributes.
-     (syntax-parse #'(or/c variant ...)
+     (syntax-parse #'(union variant ...)
        [ts:type-spec
         (with-syntax ([pred name-pred]
                       [js-pred name-js-pred]

--- a/tests/json-enum-union-test.rkt
+++ b/tests/json-enum-union-test.rkt
@@ -3,6 +3,12 @@
 (module+ test
   (require rackunit
            "../common/json-util.rkt")
+
+  (define (capture-fail-exn thunk)
+    (with-handlers ([exn:fail? values])
+      (thunk)
+      (fail "expected an exception")))
+
   ;; define-json-enum
   (define-json-enum SymbolKind
     [file 1]
@@ -65,13 +71,24 @@
 
   (test-case "union: decode and match expander"
     (check-equal? (jsexpr->DocContent "hello") "hello")
-    (check-true (Markup? (jsexpr->DocContent (hasheq 'kind "markdown" 'value "# hi"))))
-    (check-equal? (Markup-kind (jsexpr->DocContent (hasheq 'kind "markdown" 'value "# hi")))
-                  "markdown")
-    (check-exn exn:fail? (lambda () (jsexpr->DocContent 42)))
+    (define decoded (jsexpr->DocContent (hasheq 'kind "markdown" 'value "# hi")))
+    (check-true (Markup? decoded))
+    (check-equal? (Markup-kind decoded) "markdown")
     (check-equal? (match "hi" [(DocContent-js v) v]) "hi")
     (check-true (Markup? (match (hasheq 'kind "md" 'value "x")
                            [(DocContent-js v) v]))))
+
+  (test-case "union: decode failure reports unmatched value"
+    (define e (capture-fail-exn
+                (lambda ()
+                  (jsexpr->DocContent 42))))
+    (check-not-false (regexp-match? #rx"no union alternative matched value: 42" (exn-message e))))
+
+  (test-case "union: decode failure reports expected union"
+    (define e (capture-fail-exn
+                (lambda ()
+                  (jsexpr->DocContent 42))))
+    (check-not-false (regexp-match? #rx"expected: '\\(union string\\? Markup\\)" (exn-message e))))
 
   (test-case "union: as-Name"
     (check-equal? (match "ok" [(as-DocContent v) v] [_ #f]) "ok")

--- a/tests/json-struct-test.rkt
+++ b/tests/json-struct-test.rkt
@@ -2,10 +2,15 @@
 (require "../common/json-util.rkt" rackunit syntax/macro-testing)
 
 (module+ test
+  (define (capture-fail-exn thunk)
+    (with-handlers ([exn:fail? values])
+      (thunk)
+      (fail "expected an exception")))
+
   ;; Define test structs
   (define-json-struct Pos
-    [line integer?]
-    [char integer? #:json character])
+    [line exact-integer?]
+    [char exact-integer? #:json character])
 
   (define p1 (Pos 1 10))
   (define p2 (Pos #:char 20 #:line 2))
@@ -21,16 +26,23 @@
     [items (listof Pos)])
 
   (define-json-struct PosHashHolder
-    [items (hash/c symbol? Pos)])
+    [items (hashof symbol? Pos)])
 
   (define-json-struct OrPosHolder
-    [item (or/c string? Pos)])
+    [item (union string? Pos)])
 
   (define-json-struct MaybeOrPosHolder
-    [item (optional (or/c string? Pos))])
+    [item (optional (union string? Pos))])
 
   (define-json-struct OrPosListHolder
-    [items (listof (or/c string? Pos))])
+    [items (listof (union string? Pos))])
+
+  (define-json-struct CustomContractHolder
+    [item (contract integer?)])
+
+  (define-json-struct TreeNode
+    [value string?]
+    [children (listof TreeNode)])
 
   (define p-hash (hasheq 'line 10 'character 5))
   (define p-hash-2 (hasheq 'line 3 'character 30))
@@ -65,6 +77,14 @@
       (λ ()
         (convert-compile-time-error
           (Pos #:line 1 #:line 2 #:char 3)))))
+
+  (test-case "type specs: arbitrary contracts require contract form"
+    (check-exn
+      exn:fail:syntax?
+      (lambda ()
+        (convert-compile-time-error
+          (define-json-struct BadContract
+            [x (or/c string? exact-integer?)])))))
 
   (test-case "matching: Pos matches structs only"
     (check-equal?
@@ -153,26 +173,44 @@
     (check-true (Pos? (first (PosListHolder-items holder))))
     (check-equal? (Pos-line (second (PosListHolder-items holder))) 3))
 
-  (test-case "decoding: hash/c decodes compound values"
+  (test-case "decoding: hashof decodes compound values"
     (define holder (jsexpr->PosHashHolder (hasheq 'items (hasheq 'a p-hash))))
     (define decoded-pos (hash-ref (PosHashHolder-items holder) 'a))
     (check-true (Pos? decoded-pos))
     (check-equal? (Pos-char decoded-pos) 5))
 
-  (test-case "decoding: or/c chooses matching decoded variant"
+  (test-case "decoding: union chooses string variant"
     (define from-str (jsexpr->OrPosHolder (hasheq 'item "hello")))
-    (check-equal? (OrPosHolder-item from-str) "hello")
-    (define from-pos (jsexpr->OrPosHolder (hasheq 'item p-hash)))
-    (check-true (Pos? (OrPosHolder-item from-pos)))
-    (check-equal? (Pos-line (OrPosHolder-item from-pos)) 10)
-    (check-exn exn:fail? (lambda () (jsexpr->OrPosHolder (hasheq 'item 42)))))
+    (check-equal? (OrPosHolder-item from-str) "hello"))
 
-  (test-case "validation: or/c json predicate"
+  (test-case "decoding: union chooses decoded struct variant"
+    (define from-pos (jsexpr->OrPosHolder (hasheq 'item p-hash)))
+    (check-equal? (Pos-line (OrPosHolder-item from-pos)) 10))
+
+  (test-case "decoding: union failure reports field decode error"
+    (define e (capture-fail-exn
+                (lambda ()
+                  (jsexpr->OrPosHolder (hasheq 'item 42)))))
+    (check-not-false (regexp-match? #rx"failed to decode field" (exn-message e))))
+
+  (test-case "decoding: union failure reports unmatched value"
+    (define e (capture-fail-exn
+                (lambda ()
+                  (jsexpr->OrPosHolder (hasheq 'item 42)))))
+    (check-not-false (regexp-match? #rx"no union alternative matched value: 42" (exn-message e))))
+
+  (test-case "decoding: union failure reports expected union"
+    (define e (capture-fail-exn
+                (lambda ()
+                  (jsexpr->OrPosHolder (hasheq 'item 42)))))
+    (check-not-false (regexp-match? #rx"expected: '\\(union string\\? Pos\\)" (exn-message e))))
+
+  (test-case "validation: union json predicate"
     (check-true (OrPosHolder-js? (hasheq 'item "s")))
     (check-true (OrPosHolder-js? (hasheq 'item p-hash)))
     (check-false (OrPosHolder-js? (hasheq 'item 42))))
 
-  (test-case "decoding: optional with or/c"
+  (test-case "decoding: optional with union"
     (define missing (jsexpr->MaybeOrPosHolder (hasheq)))
     (check-true (Nothing? (MaybeOrPosHolder-item missing)))
     (define from-str (jsexpr->MaybeOrPosHolder (hasheq 'item "ok")))
@@ -181,7 +219,7 @@
     (check-true (Pos? (MaybeOrPosHolder-item from-pos)))
     (check-equal? (Pos-char (MaybeOrPosHolder-item from-pos)) 30))
 
-  (test-case "decoding: listof with or/c"
+  (test-case "decoding: listof with union"
     (define holder
       (jsexpr->OrPosListHolder (hasheq 'items (list "a" p-hash "b" p-hash-2))))
     (define items (OrPosListHolder-items holder))
@@ -192,6 +230,37 @@
     (check-exn exn:fail?
                (lambda ()
                  (jsexpr->OrPosListHolder (hasheq 'items (list "a" 99))))))
+
+  (test-case "decoding: explicit contract field passes through raw value"
+    (define holder (jsexpr->CustomContractHolder (hasheq 'item 1.0)))
+    (check-equal? (CustomContractHolder-item holder) 1.0)
+    (check-exn exn:fail:contract?
+               (lambda ()
+                 (jsexpr->CustomContractHolder (hasheq 'item "bad")))))
+
+  (test-case "decoding: recursive type decodes nested structs"
+    (define tree-json
+      (hasheq 'value "root"
+              'children (list (hasheq 'value "leaf"
+                                      'children '()))))
+    (define tree (jsexpr->TreeNode tree-json))
+    (check-true (TreeNode? tree))
+    (check-true (TreeNode? (first (TreeNode-children tree))))
+    (check-equal? (TreeNode-value (first (TreeNode-children tree))) "leaf"))
+
+  (test-case "decoding: field errors include type field expected value and cause"
+    (check-exn
+      (lambda (e)
+        (and (exn:fail:contract? e)
+             (regexp-match? #rx"jsexpr->TreeNode: failed to decode field" (exn-message e))
+             (regexp-match? #rx"type: 'TreeNode" (exn-message e))
+             (regexp-match? #rx"field: 'children" (exn-message e))
+             (regexp-match? #rx"expected: '\\(listof TreeNode\\)" (exn-message e))
+             (regexp-match? #rx"value: '\\(\"bad\"\\)" (exn-message e))
+             (regexp-match? #rx"cause:" (exn-message e))))
+      (lambda ()
+        (jsexpr->TreeNode (hasheq 'value "root"
+                                  'children (list "bad"))))))
 
   (test-case "matching: nested Range-js hash"
     (match r-hash
@@ -234,7 +303,7 @@
 ;; 6. Export Test
 (module export-test racket
   (require "../common/json-util.rkt")
-  (define-json-struct Exported [x integer?])
+  (define-json-struct Exported [x exact-integer?])
   (provide (json-type-out Exported))
   )
 


### PR DESCRIPTION
Before:

A bare identifier `Name` can refer to both json types or Racket predicates. It checks if decoder `jsexpr->Name` is bounded, and treat it as a json type if bounded, otherwise treat as Racket predicate. But for recursive types that decoders not yet defined, it treat `Name` as predicate and produce ambiguity bugs.

After:

It does not check anything at static or expand time. So recursive types can work now.

Because a generated decoder can reference other decoders that not defined yet, decoders are generated within lambda wrappers. The generated type contracts and predicates for jsexpr are also generated within lambda wrappers for the same reason.

Other changes:

- Bare identifiers are always treated as json types, except builtin types.
- Add `(contract C)` for Racket contract expression `C`.
- Rename DSL syntax keyword: `hash/c` to `hashof`, `or/c` to `union`.
- Add some "builtin types": `string?`, `boolean?`, `number?`, `exact-integer?`, `exact-nonnegative-integer?`, `symbol?`. they are bare identifiers, but treated as syntax sugars of `(contract string?)`, `(contract boolean?)`, etc.
- Improve error messages for decoders because they are inside anonymous lambda wrappers now.