### PR TITLE
Add Typed Racket type hover and tooltip diagnostics

### DIFF
--- a/doclib/check-syntax.rkt
+++ b/doclib/check-syntax.rkt
@@ -47,7 +47,9 @@
       (add-syntax expanded-stx)
       (done))
 
-    (ExpandResult stx expanded-stx expand-logs)))
+    ;; Interceptor conses in O(1); reverse restores emission order so overlapping
+    ;; Typed Racket provider records apply as sent.
+    (ExpandResult stx expanded-stx (reverse expand-logs))))
 
 ;; Struct to hold the result of check-syntax.
 (struct/contract CSResult

--- a/doclib/doc-trace.rkt
+++ b/doclib/doc-trace.rkt
@@ -2,6 +2,7 @@
 
 (require racket/class
          racket/set
+         racket/string
          drracket/check-syntax
          "service/completion.rkt"
          "service/hover/service.rkt"
@@ -12,7 +13,8 @@
          "service/declaration.rkt"
          "service/highlight.rkt"
          "service/typed-racket/service.rkt"
-         "service/workspace-references.rkt")
+         "service/workspace-references.rkt"
+         "../common/interfaces.rkt")
 
 (define build-trace%
   (class (annotations-mixin object%)
@@ -80,13 +82,25 @@
     ;; Chosen over putting Typed Racket type-error diagnostics on diag%:
     ;; inferred types and type errors share one online-check-syntax channel
     ;; owned by typed-racket%. Union both sets here for LSP publish.
+    ;;
+    ;; Drop a diag% Type Checker entry when some Typed Racket tooltip message
+    ;; is a substring of it (exception text is usually a longer wrapper).
+    ;; Prefer the tooltip diagnostic. If tooltips produced nothing, keep the
+    ;; exception so type errors do not disappear.
     (define/public (get-warn-diags)
       ;; Callers expect a mutable set. Fresh copy so they do not share the
       ;; diag% or typed-racket% stores.
+      (define typed-racket-diags (send typed-racket get-diagnostics))
       (define diagnostics (mutable-seteq))
-      (set-union! diagnostics
-                  (car (send diag get))
-                  (send typed-racket get-diagnostics))
+      (for ([diag (in-set (car (send diag get)))])
+        (define message (Diagnostic-message diag))
+        (define covered-by-typed-racket?
+          (and (string-contains? message "Type Checker:")
+               (for/or ([typed-diag (in-set typed-racket-diags)])
+                 (string-contains? message (Diagnostic-message typed-diag)))))
+        (unless covered-by-typed-racket?
+          (set-add! diagnostics diag)))
+      (set-union! diagnostics typed-racket-diags)
       diagnostics)
     (define/public (get-docs) (send docs get))
     (define/public (get-completions) (send completions get))

--- a/doclib/doc-trace.rkt
+++ b/doclib/doc-trace.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/class
+         racket/set
          drracket/check-syntax
          "service/completion.rkt"
          "service/hover/service.rkt"
@@ -10,11 +11,14 @@
          "service/diagnostic.rkt"
          "service/declaration.rkt"
          "service/highlight.rkt"
+         "service/typed-racket/service.rkt"
          "service/workspace-references.rkt")
 
 (define build-trace%
   (class (annotations-mixin object%)
-    (init-field src doc-text lexer-state)
+    (init-field src
+                doc-text
+                lexer-state)
     (define docs (new docs%))
     (define completions (new completion%))
     (define requires (new require%))
@@ -31,6 +35,10 @@
         [lexer-state lexer-state]))
     (define workspace-references (new workspace-references% [src src] [doc-text doc-text]))
     (define semantic-tokens (new highlight% [src src] [doc-text doc-text]))
+    (define typed-racket
+      (new typed-racket%
+        [src src]
+        [doc-text doc-text]))
 
     (define services
       (list hovers
@@ -39,6 +47,7 @@
             requires
             definitions
             diag
+            typed-racket
             decls
             workspace-references
             semantic-tokens))
@@ -66,9 +75,19 @@
     ;; Named reads for services. Do not add getters that expose interval-maps.
     (define/public (get-hover) hovers)
     (define/public (get-declaration) decls)
+    (define/public (get-typed-racket) typed-racket)
 
-    ;; Getters
-    (define/public (get-warn-diags) (car (send diag get)))
+    ;; Chosen over putting Typed Racket type-error diagnostics on diag%:
+    ;; inferred types and type errors share one online-check-syntax channel
+    ;; owned by typed-racket%. Union both sets here for LSP publish.
+    (define/public (get-warn-diags)
+      ;; Callers expect a mutable set. Fresh copy so they do not share the
+      ;; diag% or typed-racket% stores.
+      (define diagnostics (mutable-seteq))
+      (set-union! diagnostics
+                  (car (send diag get))
+                  (send typed-racket get-diagnostics))
+      diagnostics)
     (define/public (get-docs) (send docs get))
     (define/public (get-completions) (send completions get))
     (define/public (get-online-completions str-before-cursor)

--- a/doclib/doc.rkt
+++ b/doclib/doc.rkt
@@ -518,17 +518,19 @@
 (define (abs-range->range doc start end)
   (Range (doc-abs-pos->pos doc start) (doc-abs-pos->pos doc end)))
 
-;; Build hover cards: read from the hover service and docs map, build a
-;; `Hover-Card`, then render. Lookup stays here so `hover.rkt` stays testable
-;; without expansion.
+;; Build hover cards: read from the hover and Typed Racket services and the
+;; docs map, build a `Hover-Card`, then render. Lookup stays here so
+;; `hover.rkt` stays testable without expansion.
 ;;
-;; Hot path: interval-map lookup plus limited reads from the live buffer.
-;; No re-lex, expand, or cross-file load. Source detail uses shifted ranges
-;; while a trace is old. The result can be wrong or incomplete. Do not wait for
-;; `doc-trace-latest?`. Limits match features.md.
+;; Performance: hot path is interval-map lookup plus limited reads from the
+;; live buffer. No re-lex, expand, or cross-file load. Do not wait for
+;; `doc-trace-latest?`; shifted source detail and retained types may be wrong
+;; or incomplete while a trace is old.
+;; Caps live in `max-hover-source-*` here and the comment caps in
+;; `service/hover/detail.rkt`; keep Scribble `doc-hover` in sync.
 
 (define (hover-tag->signature tag)
-  ;; Prefer bluebox signatures over HTML for the summary fence. They indent
+  ;; Prefer bluebox signatures over HTML for the definition fence. They indent
   ;; better. When this returns #f, `hover-documentation-text` may still take a
   ;; signature from HTML docs via #:include-signature? #t.
   (match-define (list signatures args-description)
@@ -542,9 +544,9 @@
                ""))))
 
 (define (hover-documentation-text link signature)
-  ;; Skip the HTML signature when a bluebox signature already fills the summary.
-  ;; Otherwise `extract-documentation` puts the same signature in the docs body
-  ;; (see #:include-signature? in documentation-parser.rkt).
+  ;; Skip the HTML signature when a bluebox signature already fills the
+  ;; definition slot. Otherwise `extract-documentation` puts the same signature
+  ;; in the docs body (see #:include-signature? in documentation-parser.rkt).
   (if link
       (or (extract-documentation-for-selected-element
             link #:include-signature? (not signature))
@@ -650,20 +652,6 @@
                   "\n")
                 (Hover-Detail-fence-language detail))))))
 
-(define (build-hover-card hover-text link signature source-summary documentation-text)
-  ;; Same-file source form wins over a docs signature. Keep check-syntax text
-  ;; unchanged in a labeled fact. Do not rewrite it in the renderer.
-  (Hover-Card (or source-summary
-                  (and signature
-                       (Hover-Code-Summary signature "racket")))
-              '()
-              (if hover-text
-                  (list (Hover-Fact "Check syntax" hover-text))
-                  '())
-              (and link
-                   (Hover-Documentation documentation-text
-                                        (make-proper-url-for-online-documentation link)))))
-
 ;; Find same-file detail through use-to-declaration lookup. Skip imports and
 ;; cross-file `Decl-filepath` values. Keep the use span even when no stored
 ;; detail exists yet, so mouse-over range fallback still works.
@@ -682,11 +670,15 @@
   (define doc-trace (Doc-trace doc))
   (define hover-service (send doc-trace get-hover))
   (define declaration-service (send doc-trace get-declaration))
+  (define typed-racket-service
+    (send doc-trace get-typed-racket))
   (define pos* (doc-pos->abs-pos doc pos))
   (define-values (start end hover-text)
     (send hover-service mouse-over-at pos*))
+  (define-values (type-start type-end type-text)
+    (send typed-racket-service inferred-type-at pos*))
   ;; While a trace refreshes, show current buffer text from shifted ranges.
-  ;; The binding link may be old or wrong.
+  ;; The binding link or retained type may be old or wrong.
   (define-values (detail-start detail-end detail)
     (send hover-service source-detail-at pos*))
   (define-values (use-start use-end resolved-detail)
@@ -696,9 +688,10 @@
   (define source-summary
     (and resolved-detail (hover-detail->summary doc resolved-detail)))
   (cond
-    ;; Docs alone do not open a card. Stored source detail may still supply
-    ;; summary and range when check-syntax produced no hover text.
-    [(and (not hover-text) (not source-summary)) #f]
+    ;; Docs alone do not open a card. Type text, check-syntax hover, or
+    ;; same-file source summary each can. Stored source detail may still
+    ;; supply summary and range when check-syntax produced no hover text.
+    [(and (not type-text) (not hover-text) (not source-summary)) #f]
     [else
      (match-define (list link tag)
        (interval-map-ref (send doc-trace get-docs) pos* (list #f #f)))
@@ -706,16 +699,21 @@
      (define documentation-text
        (hover-documentation-text link signature))
      (define hover-card
-       (build-hover-card hover-text
-                         link
-                         signature
-                         source-summary
-                         documentation-text))
+       (build-hover-card #:type-text type-text
+                         #:type-stale? (not (doc-trace-latest? doc))
+                         #:hover-text hover-text
+                         #:link (and link
+                                     (make-proper-url-for-online-documentation link))
+                         #:signature signature
+                         #:source-summary source-summary
+                         #:documentation-text documentation-text))
      (Hover #:contents (render-hover-card hover-card)
+            ;; Prefer inferred-type intervals, including literal and expression
+            ;; delimiter spans Typed Racket can publish without mouse-over text.
+            ;; Fall back to check-syntax mouse-over or kept source-detail range.
             #:range (abs-range->range doc
-                                      (or start use-start)
-                                      (or end use-end)))]))
-
+                                      (or type-start start use-start)
+                                      (or type-end end use-end)))]))
 (define/contract (doc-code-action doc range)
   (-> Doc? Range? (listof CodeAction?))
   (define doc-trace (Doc-trace doc))

--- a/doclib/hover.rkt
+++ b/doclib/hover.rkt
@@ -1,99 +1,151 @@
 #lang racket/base
 
-;; Data for a hover card. Other code fills the fields. This module turns them
-;; into Markdown.
+;; Hover card data and Markdown rendering.
 ;;
-;; Keep this module as data only. `doc-hover` collects check-syntax and docs,
-;; then calls `render-hover-card`. All cards use the same layout.
+;; `doc-hover` collects type, check-syntax, source, and docs facts, then
+;; `build-hover-card` maps them onto fixed slots and `render-hover-card`
+;; turns the card into Markdown. All cards use the same layout.
 ;;
-;; Section order is fixed: summary, metadata, facts, documentation.
-;; Do not build hover strings outside this model
-;; (see tests/lib/doc-test.rkt hover cases).
+;; Invariant: the renderer decides only whether a slot appears and where it
+;; appears. Every character inside a slot is verbatim from its source. Do not
+;; trim, inline, paraphrase, or length-gate presentation here.
+;;
+;; Fixed render order: type, definition, documentation (link then body), note.
+;; Always label a type fence (`Type` / `Type (stale)`). Label `Source` or
+;; `Signature` only when a type fence precedes the definition. The note is
+;; unlabeled prose.
 
 (require racket/contract
-         racket/string)
+         racket/match
+         racket/string
+         srfi/2)
 
 (provide (struct-out Hover-Card)
          (struct-out Hover-Code-Summary)
-         (struct-out Hover-Fact)
+         (struct-out Hover-Definition)
          (struct-out Hover-Documentation)
-         render-hover-card)
+         build-hover-card
+         render-hover-card
+         hover-card-has-content?)
 
-;; Signature or source snippet inside a Markdown code fence.
-;; If text is empty, skip the whole summary section when rendering.
+;; One fenced code block (type, source, or signature text).
+;; Empty text omits that fence when rendering.
 (struct/contract Hover-Code-Summary
   ([text string?]
    [fence-language string?])
   #:transparent)
 
-;; One labeled fact. Rendered as `Label: value`.
-;; Skip the fact if label or value is empty.
-(struct/contract Hover-Fact
-  ([label string?]
-   [value string?])
+;; Definition slot: same-file source form or a docs signature.
+(struct/contract Hover-Definition
+  ([kind (or/c 'source 'signature)]
+   [summary Hover-Code-Summary?])
   #:transparent)
 
-;; Documentation section. It can follow a `---` separator.
-;; Body may be empty if only the online link should show.
-;; Put the link before a long body.
+;; Documentation slot. At most one `---` precedes it, and only when earlier
+;; slots are also present. Body may be empty when only the online link should
+;; show; link comes before a long body.
 (struct/contract Hover-Documentation
   ([body string?]
    [link (or/c string? #f)])
   #:transparent)
 
-;; Summary is a fenced code block, or it is missing. Put other hover text in
-;; `facts` or `metadata`. Do not use a second summary style.
-;;
-;; `summary`: fenced signature or source snippet. `doc-hover` puts check-syntax
-;;   text in `facts`, not here.
-;; `metadata`: short source labels joined with ` | `. Empty strings are
-;;   dropped when rendering.
-;; `facts`: labeled lines (type, contract, ...) in the order they were added.
-;; `documentation`: last section. Skip it when body and link are both empty.
+;; Fixed slots. Use #f to omit a slot. Documentation may be link-only with an
+;; empty body.
+;; Struct field order is not render order: `note` sits before `documentation`
+;; here, but render places documentation before note (see module header).
+;; `type-stale?` matters only when `type` is present.
+;; `note` holds check-syntax mouse-over text; `build-hover-card` clears it when
+;; any richer slot is present.
 (struct/contract Hover-Card
-  ([summary (or/c Hover-Code-Summary? #f)]
-   [metadata (listof string?)]
-   [facts (listof Hover-Fact?)]
+  ([type (or/c Hover-Code-Summary? #f)]
+   [type-stale? boolean?]
+   [definition (or/c Hover-Definition? #f)]
+   [note (or/c string? #f)]
    [documentation (or/c Hover-Documentation? #f)])
   #:transparent)
+
+;; Map hover inputs onto the fixed renderer slots.
+;; Same-file source wins over a docs signature.
+;; Check-syntax text is fallback-only: keep it only when no type, definition,
+;; or docs link exists. Do not classify its mixed strings here.
+;; `#:link` is the final online URL (caller rewrites local docs paths).
+(define (build-hover-card #:type-text type-text
+                          #:type-stale? type-stale?
+                          #:hover-text hover-text
+                          #:link link
+                          #:signature signature
+                          #:source-summary source-summary
+                          #:documentation-text documentation-text)
+  (define type
+    (and type-text
+         (Hover-Code-Summary type-text "racket")))
+  (define definition
+    (cond
+      [source-summary
+       (Hover-Definition 'source source-summary)]
+      [signature
+       (Hover-Definition 'signature
+                         (Hover-Code-Summary signature "racket"))]
+      [else #f]))
+  (define documentation
+    (and link
+         (Hover-Documentation documentation-text link)))
+  (define note
+    (and hover-text
+         (not type)
+         (not definition)
+         (not documentation)
+         hover-text))
+  (Hover-Card type
+              ;; Caller sets type-stale? for the whole document; attach it only
+              ;; when a type fence exists so note-only cards stay unmarked.
+              (and type type-stale?)
+              definition
+              note
+              documentation))
 
 (define (non-empty-text? text)
   (and (string? text)
        (not (string=? text ""))))
 
-(define (render-summary summary)
-  (cond
-    [(not summary) #f]
-    [(Hover-Code-Summary? summary)
-     (define text (Hover-Code-Summary-text summary))
-     (define fence-language (Hover-Code-Summary-fence-language summary))
-     (and (non-empty-text? text)
-          (format "```~a\n~a\n```" fence-language text))]
-    [else
-     (raise-argument-error 'render-hover-card
-                           "(or/c Hover-Code-Summary? #f)"
-                           summary)]))
+(define (render-code-summary summary)
+  (define text (Hover-Code-Summary-text summary))
+  (define fence-language (Hover-Code-Summary-fence-language summary))
+  (and (non-empty-text? text)
+       (format "```~a\n~a\n```" fence-language text)))
 
-;; Join metadata with ` | ` next to the summary.
-;; Drop empty entries so missing data does not leave extra separators.
-(define (render-metadata metadata)
-  (define entries
-    (for/list ([entry (in-list metadata)]
-               #:when (non-empty-text? entry))
-      entry))
-  (and (pair? entries)
-       (string-join entries " | ")))
+;; Tight label-to-fence pairing. Blank lines belong between slots, not here.
+(define (render-labeled-fence label summary)
+  (define fenced (render-code-summary summary))
+  (and fenced
+       (format "**~a**\n~a" label fenced)))
 
-(define (render-facts facts)
-  (define lines
-    (for/list ([fact (in-list facts)]
-               #:when (and (non-empty-text? (Hover-Fact-label fact))
-                           (non-empty-text? (Hover-Fact-value fact))))
-      (format "~a: ~a"
-              (Hover-Fact-label fact)
-              (Hover-Fact-value fact))))
-  (and (pair? lines)
-       (string-join lines "\n")))
+(define (render-type type type-stale?)
+  (and type
+       (render-labeled-fence (if type-stale?
+                                 "Type (stale)"
+                                 "Type")
+                             type)))
+
+(define (definition-label kind)
+  (match kind
+    ['source "Source"]
+    ['signature "Signature"]))
+
+;; Label only when a type fence precedes this slot. A lone definition fence
+;; stays unlabeled so it matches the old single-fence hover layout; two
+;; adjacent fences need labels.
+(define (render-definition definition #:label? label?)
+  (and-let* (definition
+              [summary (Hover-Definition-summary definition)])
+    (if label?
+        (render-labeled-fence (definition-label (Hover-Definition-kind definition))
+                              summary)
+        (render-code-summary summary))))
+
+(define (render-note note)
+  (and (non-empty-text? note)
+       note))
 
 (define (render-documentation documentation)
   (cond
@@ -103,11 +155,8 @@
      (define link (Hover-Documentation-link documentation))
      ;; Put the link before the body. A long excerpt can hide a link at the end.
      (define header
-       (cond
-         [(non-empty-text? link)
-          (format "[Online docs](~a)" link)]
-         [(non-empty-text? body) "Documentation"]
-         [else #f]))
+       (and (non-empty-text? link)
+            (format "[Online docs](~a)" link)))
      (define parts
        (append (if header
                    (list header)
@@ -118,25 +167,46 @@
      (and (pair? parts)
           (string-join parts "\n\n"))]))
 
+;; Chosen over checking raw fields: documentation may be link-only with an
+;; empty body, and empty fences must not count as content.
+(define (hover-card-has-content? card)
+  (or (Hover-Card-type card)
+      (Hover-Card-definition card)
+      (non-empty-text? (Hover-Card-note card))
+      (match (Hover-Card-documentation card)
+        [#f #f]
+        [(Hover-Documentation body link)
+         (or (non-empty-text? body)
+             (non-empty-text? link))])))
+
 (define/contract (render-hover-card card)
   (-> Hover-Card? string?)
-  (define summary (render-summary (Hover-Card-summary card)))
-  (define metadata (render-metadata (Hover-Card-metadata card)))
-  (define facts (render-facts (Hover-Card-facts card)))
+  (define type
+    (render-type (Hover-Card-type card)
+                 (Hover-Card-type-stale? card)))
+  (define definition
+    (render-definition (Hover-Card-definition card)
+                       #:label? (and type #t)))
   (define documentation
     (render-documentation (Hover-Card-documentation card)))
-  (define non-doc-sections
-    (filter non-empty-text?
-            (list summary metadata facts)))
-  (define non-doc-contents
-    (string-join non-doc-sections "\n\n"))
-  ;; Use at most one `---` separator, and only before the docs section.
-  ;; Do not put separators between summary, metadata, and facts. Skip the
-  ;; separator when docs are empty (see "Hover card omits empty sections...").
+  (define note
+    (render-note (Hover-Card-note card)))
+  (define before-docs
+    (string-join
+      (filter non-empty-text?
+              (list type definition))
+      "\n\n"))
+  ;; At most one `---`, only before docs, and only when both sides are non-empty.
+  (define with-docs
+    (cond
+      [(not documentation) before-docs]
+      [(string=? before-docs "") documentation]
+      [else
+       (string-append before-docs
+                      "\n\n---\n\n"
+                      documentation)]))
   (cond
-    [(not documentation) non-doc-contents]
-    [(string=? non-doc-contents "") documentation]
+    [(not note) with-docs]
+    [(string=? with-docs "") note]
     [else
-     (string-append non-doc-contents
-                    "\n\n---\n\n"
-                    documentation)]))
+     (string-append with-docs "\n\n" note)]))

--- a/doclib/service/diagnostic.rkt
+++ b/doclib/service/diagnostic.rkt
@@ -20,6 +20,9 @@
 
 (provide diag%)
 
+;; Language-independent diagnostics from expansion exceptions, language-policy
+;; checks, and check-syntax mouse-over hints. Typed Racket type-error tooltips
+;; live on typed-racket%, not here.
 (define diag%
   (class base-service%
     (init-field src doc-text lexer-state)
@@ -54,12 +57,6 @@
         (add-diags! (error-diagnostics doc-text pre-exn)))
       (when post-exn
         (add-diags! (error-diagnostics doc-text post-exn))))
-
-    (define/override (walk-log logs)
-      (for ([log (in-list logs)])
-        (define result (check-typed-racket-log doc-text log))
-        (when (list? result)
-          (add-diags! result))))
 
     (define/override (syncheck:add-mouse-over-status src-obj start finish text)
       (when (and (< start finish)
@@ -148,9 +145,9 @@
 (define (error-diagnostics doc-text exn)
   (define msg (exn-message exn))
   (cond
-    ;; Typed Racket reports each type error separately, then emits a final
-    ;; "Type Checker: Summary" message that repeats the error count. The
-    ;; per-error diagnostics are more useful, so do not publish the summary.
+    ;; Do not publish Typed Racket's final "Type Checker: Summary" exception.
+    ;; It only repeats the error count; per-error text comes from typed-racket%
+    ;; tooltips.
     [(string-prefix? msg "Type Checker: Summary") (list)]
     ;; A .zo file was compiled by a different Racket version. The original
     ;; reader error is hard to act on, so rewrite it into a recompilation
@@ -258,21 +255,3 @@
      (string-append
        "Cannot find required module.\n"
        "Check that the module or collection name is correct and the package is installed.")]))
-
-(define (check-typed-racket-log doc-text log)
-  (match-define (vector _ msg data _) log)
-  (when (and (list? data) (not (empty? data)) (syntax? (car data)))
-    (define prop (syntax-property (car data) 'mouse-over-tooltips))
-    (when (and prop (list? prop) (not (empty? prop)))
-      (define-values (start end msg)
-        (match prop
-          [(list (vector _ start _ _) (vector _ _ end msg))
-           (values start end msg)]
-          [(list (vector _ start end msg))
-           (values start end msg)]
-          [else (values #f #f #f)]))
-      (when (string? msg)
-        (list (Diagnostic #:range (Range #:start (abs-pos->Pos doc-text start) #:end (abs-pos->Pos doc-text end))
-                          #:severity DiagnosticSeverity-Error
-                          #:source "Typed Racket"
-                          #:message msg))))))

--- a/doclib/service/typed-racket/decoder.rkt
+++ b/doclib/service/typed-racket/decoder.rkt
@@ -1,0 +1,228 @@
+#lang racket/base
+
+;; Convert Typed Racket online-check-syntax log records into normalized
+;; annotations.
+;;
+;; Typed Racket does not put type tooltips on the final expanded syntax that
+;; check-syntax walks. During expand it logs syntax objects that carry
+;; 'mouse-over-tooltips; this module reads that log channel instead.
+;;
+;; Approach and leaf walk follow racket-mode's online-check-syntax handling
+;; (racket-xp-mode):
+;; https://github.com/greghendershott/racket-mode/blob/master/racket/online-check-syntax.rkt
+;; We adapt it for LSP: classify TR message suffixes, and split inferred types
+;; (hover) from type-error tooltips (diagnostics).
+;;
+;; Keep classification narrow. Other languages may use the same log topic and
+;; 'mouse-over-tooltips property for different purposes.
+
+(require racket/contract
+         racket/list
+         racket/match
+         racket/string
+         srfi/2)
+
+(provide (struct-out Inferred-Type)
+         (struct-out Type-Error)
+         typed-racket-inferred-type-message
+         typed-racket-type-error-message
+         typed-racket-log-annotations)
+
+;; Invariant: these suffixes are the only classification rule for TR tooltip
+;; logs. Keep the strings exact. Match with string-suffix? so an optional
+;; topic prefix (for example "online-check-syntax: ") still classifies.
+(define typed-racket-inferred-type-message
+  "TR's tooltip syntaxes; this message is ignored")
+
+(define typed-racket-type-error-message
+  "TR's type error tooltip syntaxes; this message is ignored")
+
+;; Decoded tooltip leaf. Kind turns these into Inferred-Type or Type-Error.
+(struct/contract Mouseover
+  ([source path-string?]
+   [start exact-nonnegative-integer?]
+   [end exact-nonnegative-integer?]
+   [text string?])
+  #:transparent)
+
+(struct/contract Inferred-Type
+  ([source path-string?]
+   [start exact-nonnegative-integer?]
+   [end exact-nonnegative-integer?]
+   [text string?])
+  #:transparent)
+
+(struct/contract Type-Error
+  ([source path-string?]
+   [start exact-nonnegative-integer?]
+   [end exact-nonnegative-integer?]
+   [message string?])
+  #:transparent)
+
+(define (tooltip-text? value)
+  (or (string? value)
+      (and (procedure? value)
+           (procedure-arity-includes? value 0))))
+
+;; 'mouse-over-tooltips leaf on supported Racket versions:
+;; (vector located-syntax start end text-or-thunk).
+;; The property value is an arbitrary pair tree of such leaves.
+
+;; Syntax that carries the tooltip source; used to keep this document only.
+(define (tooltip-leaf-located-syntax leaf)
+  (vector-ref leaf 0))
+
+;; Absolute character offset where the tooltip span starts.
+(define (tooltip-leaf-start leaf)
+  (vector-ref leaf 1))
+
+;; Absolute character offset where the tooltip span ends.
+(define (tooltip-leaf-end leaf)
+  (vector-ref leaf 2))
+
+;; String text, or a zero-arg thunk that returns it.
+(define (tooltip-leaf-text-or-thunk leaf)
+  (vector-ref leaf 3))
+
+(define (tooltip-leaf? value)
+  (and (vector? value)
+       (= (vector-length value) 4)
+       (syntax? (tooltip-leaf-located-syntax value))
+       (exact-nonnegative-integer? (tooltip-leaf-start value))
+       (exact-nonnegative-integer? (tooltip-leaf-end value))
+       (tooltip-text? (tooltip-leaf-text-or-thunk value))))
+
+;; Decode one leaf for this document, or #f when foreign, empty, or malformed.
+;; Do not force a provider thunk before the source check: foreign-source
+;; tooltip code must not run while analyzing this document.
+(define (tooltip-leaf->mouseover leaf source)
+  (define located-syntax (tooltip-leaf-located-syntax leaf))
+  (define start (tooltip-leaf-start leaf))
+  (define end (tooltip-leaf-end leaf))
+  (define text-or-thunk (tooltip-leaf-text-or-thunk leaf))
+  (and-let* ([(equal? source (syntax-source located-syntax))]
+             [(< start end)]
+             [text (if (string? text-or-thunk)
+                       text-or-thunk
+                       (text-or-thunk))]
+             [(string? text)]
+             [(not (string=? text ""))])
+    (Mouseover source start end text)))
+
+(define (tooltip-property->mouseovers property source)
+  (define mouseovers '())
+
+  (define (walk value)
+    (cond
+      [(pair? value)
+       (walk (car value))
+       (walk (cdr value))]
+      [(tooltip-leaf? value)
+       (define mouseover (tooltip-leaf->mouseover value source))
+       (when mouseover
+         (set! mouseovers (cons mouseover mouseovers)))]))
+
+  (walk property)
+  (reverse mouseovers))
+
+;; online-check-syntax log vector: (vector level message data topic)
+(define (log-message log)
+  ;; Log message string; TR classification matches its suffix.
+  (vector-ref log 1))
+(define (log-data log)
+  ;; Payload: list of syntax objects that carry 'mouse-over-tooltips.
+  (vector-ref log 2))
+(define (log-topic log)
+  ;; Must be 'online-check-syntax for records we handle.
+  (vector-ref log 3))
+
+;; Classify by message suffix only (see invariant above). #f for any other
+;; online-check-syntax record.
+(define (typed-racket-log-kind log)
+  (and-let* ([(vector? log)]
+             [(= (vector-length log) 4)]
+             [(eq? (log-topic log) 'online-check-syntax)]
+             [message (log-message log)]
+             [(string? message)])
+    (cond
+      [(string-suffix? message typed-racket-inferred-type-message)
+       'inferred-type]
+      [(string-suffix? message typed-racket-type-error-message)
+       'type-error]
+      [else #f])))
+
+(define (log-payload-syntaxes log)
+  (define data (log-data log))
+  (and (list? data)
+       (andmap syntax? data)
+       data))
+
+;; A type error may use two endpoint mouseovers for a compound form. Typed
+;; Racket emits one log record per error, so equal-message endpoints describe
+;; one range. Distinct messages stay separate diagnostics.
+(define (mouseovers->type-errors mouseovers)
+  (match mouseovers
+    ['() '()]
+    [(cons first-mouseover rest-mouseovers)
+     (define shared-message?
+       (for/and ([mouseover (in-list rest-mouseovers)])
+         (and (equal? (Mouseover-source mouseover)
+                      (Mouseover-source first-mouseover))
+              (string=? (Mouseover-text mouseover)
+                        (Mouseover-text first-mouseover)))))
+     (cond
+       [shared-message?
+        ;; Union the endpoint ranges: min start .. max end.
+        (list (Type-Error (Mouseover-source first-mouseover)
+                          (apply min (map Mouseover-start mouseovers))
+                          (apply max (map Mouseover-end mouseovers))
+                          (Mouseover-text first-mouseover)))]
+       [else
+        (for/list ([mouseover (in-list mouseovers)])
+          (Type-Error (Mouseover-source mouseover)
+                      (Mouseover-start mouseover)
+                      (Mouseover-end mouseover)
+                      (Mouseover-text mouseover)))])]))
+
+(define (log-record->annotations log kind source)
+  (define syntaxes (log-payload-syntaxes log))
+  (cond
+    [(not syntaxes) '()]
+    [else
+     (define mouseovers
+       (append*
+         (for/list ([stx (in-list syntaxes)])
+           ;; Do not traverse the logged syntax datum. It is only a carrier for
+           ;; 'mouse-over-tooltips. Walking it pulls unrelated annotations and
+           ;; needs the original expansion namespace.
+           (tooltip-property->mouseovers
+             (syntax-property stx 'mouse-over-tooltips)
+             source))))
+     (case kind
+       [(inferred-type)
+        (for/list ([mouseover (in-list mouseovers)])
+          (Inferred-Type (Mouseover-source mouseover)
+                         (Mouseover-start mouseover)
+                         (Mouseover-end mouseover)
+                         (Mouseover-text mouseover)))]
+       [(type-error)
+        (mouseovers->type-errors mouseovers)])]))
+
+(define/contract (typed-racket-log-annotations logs source)
+  (-> (listof vector?)
+      path-string?
+      (listof (or/c Inferred-Type? Type-Error?)))
+  (append*
+    (for/list ([log (in-list logs)])
+      (define kind (typed-racket-log-kind log))
+      (cond
+        [(not kind) '()]
+        [else
+         ;; One malformed provider record must not abort the rest of the batch.
+         (with-handlers ([exn:fail?
+                          (lambda (exn)
+                            (eprintf "Ignoring malformed Typed Racket ~a record: ~a\n"
+                                     kind
+                                     (exn-message exn))
+                            '())])
+           (log-record->annotations log kind source))]))))

--- a/doclib/service/typed-racket/service.rkt
+++ b/doclib/service/typed-racket/service.rkt
@@ -1,0 +1,86 @@
+#lang racket/base
+
+;; Typed Racket analysis from the online Check Syntax log stream.
+;;
+;; This service owns both products of that channel: inferred types and
+;; type-error diagnostics. Keep them here so diag% stays language-independent
+;; (see get-warn-diags in doc-trace.rkt).
+
+(require "../interface.rkt"
+         "decoder.rkt"
+         "../../../common/interfaces.rkt"
+         racket/class
+         racket/match
+         racket/set
+         data/interval-map)
+
+(provide typed-racket%)
+
+(define typed-racket%
+  (class base-service%
+    (init-field src
+                doc-text)
+    (super-new)
+
+    ;; Absolute character range -> inferred type text.
+    (define type-by-range
+      (make-interval-map))
+    (define diagnostics
+      (mutable-seteq))
+
+    ;; Return start/end/text only. Callers must not hold or mutate the
+    ;; interval-map while expand/contract shifts ranges during an edit.
+    (define/public (inferred-type-at pos)
+      (interval-map-ref/bounds type-by-range pos #f))
+
+    (define/public (get-diagnostics)
+      diagnostics)
+
+    (define/override (reset)
+      (set! type-by-range (make-interval-map))
+      (set-clear! diagnostics))
+
+    (define/override (expand start end)
+      (interval-map-expand! type-by-range start end))
+
+    (define/override (contract start end)
+      (interval-map-contract! type-by-range start end))
+
+    (define/override (walk-log log)
+      (for ([record (in-list (typed-racket-log-annotations log src))])
+        (match record
+          [(? Inferred-Type?)
+           (record-inferred-type! record)]
+          [(? Type-Error?)
+           (record-type-error! record)])))
+
+    ;; Provider offsets must fit the document snapshot. Invalid LSP ranges are
+    ;; worse than omitting one malformed tooltip.
+    (define/private (document-range? start end)
+      (and (< start end)
+           (<= end (send doc-text end-pos))))
+
+    (define/private (record-inferred-type! inferred-type)
+      (match-define (struct* Inferred-Type
+                      ([start start]
+                       [end end]
+                       [text text]))
+        inferred-type)
+      (when (document-range? start end)
+        (interval-map-set! type-by-range start end text)))
+
+    (define/private (record-type-error! type-error)
+      (match-define (struct* Type-Error
+                      ([start start]
+                       [end end]
+                       [message message]))
+        type-error)
+      (when (document-range? start end)
+        (set-add!
+          diagnostics
+          (Diagnostic #:range
+                      (Range #:start (abs-pos->Pos doc-text start)
+                             #:end (abs-pos->Pos doc-text end))
+                      #:severity DiagnosticSeverity-Error
+                      #:source "Typed Racket"
+                      #:message message))))))

--- a/features.md
+++ b/features.md
@@ -52,7 +52,7 @@ Problems are shown from these sources:
 
 - **Reader and expander errors** (syntax errors, missing modules, broken `.zo` files). Shown even if expansion fails. `.zo` version mismatch errors include a suggestion telling you which `raco` command to run.
 - **Check-syntax warnings** for unused variables and unused `require` forms. These only appear after a successful expansion. Powered by DrRacket's `check-syntax`.
-- **Typed Racket type errors** produced during expansion by the type checker. The server reads these from the type checker's log output.
+- **Typed Racket type errors** produced during expansion by the type checker. The server reads these from Typed Racket's online-check-syntax tooltip channel (same source as inferred types on hover).
 - **Language declaration check** warns about missing `#lang` lines or unrecognized language names. Works without expansion.
 
 Language behavior: mostly not filtered by language family. Reader errors, expander errors, and check-syntax warnings work for any language that reads and expands. The language declaration check only recognizes the predefined language families, so other valid `#lang` names are reported as unrecognized. Typed Racket type errors are specific to Typed Racket.
@@ -83,14 +83,44 @@ Language behavior: only recognized sexp language families are supported. Other l
 
 ## Hover *(requires expansion)*
 
-Hovering over an identifier shows:
+Hovering at a position shows a fixed Markdown card. The renderer only chooses
+whether each slot appears and where it appears; slot text stays verbatim from
+its source.
 
-1. **Same-file source form** - for local declarations and uses confirmed by the trace, a limited structural snippet from the bound declaration. Local uses share that declaration detail. They do not show the use-site form. Display prefers the outermost same-line structural candidate when one exists: a compact binding clause, a collapsed one-line header, or a complete one-line form. Otherwise it shows the full nearest enclosing form. Contiguous own-line leading comments above the form are included. Racket-family forms use a `racket` fence. Rhombus forms use a `rhombus` fence. This does not depend on recognizing binding-form names.
-2. **Check syntax** - the raw mouse-over status from check syntax, shown unchanged with a `Check syntax:` label.
-3. **Online docs link** - from check-syntax's doc annotation, turned into a `docs.racket-lang.org` URL.
-4. **Locally installed documentation** - looked up via the check-syntax doc tag. Scribble blueboxes are preferred for formatted signatures. If they are not available, the locally installed HTML docs are parsed instead.
+Slots, top to bottom:
 
-Language behavior: source forms are read from the current buffer using kept trace ranges while a refresh runs. When the trace is old, the shown form can be useful, but the binding link can be outdated. Code context is limited to 10 lines and 1000 source characters. Leading comments are limited to 10 lines and 200 source characters per line. Other hover data works where expansion succeeds and check-syntax produces hover and documentation data with reliable source ranges.
+1. **Type** - Typed Racket inferred type in a `racket` fence, labeled `Type` or
+   `Type (stale)` when it comes from a retained trace. Always fenced; never
+   inlined by length.
+2. **Definition** - same-file source snippet when the trace confirms a local
+   declaration or use, otherwise a Scribble bluebox / docs signature. Source
+   wins when both exist. Local uses share declaration detail. Display prefers
+   the outermost same-line structural candidate when one exists: a compact
+   binding clause, a collapsed one-line header, or a complete one-line form.
+   Otherwise it shows the full nearest enclosing form. Contiguous own-line
+   leading comments above the form are included. Racket-family forms use a
+   `racket` fence. Rhombus forms use a `rhombus` fence. A lone definition
+   fence is unlabeled; when a type precedes it, the fence is labeled `Source`
+   or `Signature`.
+3. **Documentation** - online docs link, then locally installed docs excerpt
+   when available. At most one `---` appears, and only immediately before this
+   section when earlier slots are also present.
+4. **Check-syntax text** - raw mouse-over status, unlabeled, and only when it
+   is the sole content (no type, definition, or docs link). Occurrence counts
+   and `imported from ...` are not classified specially; they disappear when
+   richer slots already fill the card.
+
+Language behavior: source forms are read from the current buffer using kept
+trace ranges while a refresh runs. When the trace is old, retained types stay
+visible as `Type (stale)`. The shown form or type can be useful, but the
+binding link or type may be wrong until expansion finishes. The hover range
+prefers the inferred-type interval when present (including literal and
+expression-delimiter spans); otherwise it uses check-syntax mouse-over status
+or a kept same-file source-detail range. Code context is limited to 10 lines
+and 1000 source characters. Leading comments are limited to 10 lines and 200
+source characters per line. Other hover data works where expansion succeeds
+and check-syntax produces hover and documentation data with reliable source
+ranges.
 
 ## Inlay Hints
 

--- a/scribblings/racket-langserver.scrbl
+++ b/scribblings/racket-langserver.scrbl
@@ -106,35 +106,42 @@ from @tt{racket-langserver/json-util}. Nested struct values are encoded recursiv
 @defstruct*[Hover ([contents string?]
                    [range Range?])
             #:transparent]{
-  Hover information for a symbol occurrence.
+  Hover information at a document position.
 
   The @tt{contents} field is Markdown from a @tt{Hover-Card}. Sections appear in
   this fixed order:
   @itemlist[
-    @item{Optional fenced code summary. For a current same-file trace with local
+    @item{Optional Typed Racket type in a @tt{racket} fence. Labeled @tt{Type},
+          or @tt{Type (stale)} when the type comes from a retained trace.}
+    @item{Optional fenced definition. For a current same-file trace with local
           declaration detail, this shows code around the bound declaration.
-          Local uses share that detail. Each use does not rebuild it. Own-line
-          leading comments above the form may also appear. Usually the summary
-          shows the outermost same-line form (a compact binding clause, a
-          one-line header collapsed with @tt{...}, or a complete one-line form).
-          When no form on the identifier line fits, the full nearest enclosing
-          form is shown. Without same-file detail, a Scribble bluebox signature
-          may fill the summary instead. Racket-family forms use a @tt{racket}
-          fence. Rhombus forms use a @tt{rhombus} fence.}
-    @item{A @tt{Check syntax:} line from check-syntax mouse-over status, when
-          present. The text is unchanged.}
-    @item{Optional documentation after a @tt{---} separator: an online link
-          and/or a locally installed docs excerpt}
+          Local uses share that stored detail; each use does not rebuild it.
+          Own-line leading comments above the form may also appear. Usually this
+          slot shows the outermost same-line form (a compact binding clause,
+          a one-line header collapsed with @tt{...}, or a complete one-line
+          form). When no form on the identifier line fits, the full nearest
+          enclosing form is shown. Without same-file detail, a Scribble bluebox
+          signature may fill this slot instead. Racket-family forms use a
+          @tt{racket} fence. Rhombus forms use a @tt{rhombus} fence. A lone
+          definition fence is unlabeled. When a type precedes it, the fence is
+          labeled @tt{Source} or @tt{Signature}.}
+    @item{Optional documentation after a @tt{---} separator when earlier slots
+          are also present: an online link and/or a locally installed docs
+          excerpt. Link comes before body.}
+    @item{Optional check-syntax mouse-over text as a plain unlabeled note, only
+          when it is the sole content (no type, definition, or docs link). The
+          text is unchanged.}
   ]
 
   When a trace is old, same-file source detail still comes from the current
-  buffer. The shown form can be useful, but the binding link may be wrong until
-  expansion finishes. Imports and cross-file bindings do not get same-file
-  source snippets. Their cards use check-syntax text and documentation instead.
+  buffer and retained types remain visible as stale. These results can be
+  useful, but the binding link or type may be wrong until expansion finishes.
+  Imports and cross-file bindings do not get same-file source snippets. Their
+  cards use documentation when available, otherwise check-syntax text alone.
 
-  The @tt{range} field is the identifier span the hover applies to. It comes from
-  check-syntax mouse-over status when present. Otherwise it comes from a kept
-  same-file source-detail range.
+  The @tt{range} field comes from the inferred-type interval when present,
+  including literal and expression-delimiter intervals. Otherwise it comes
+  from check-syntax mouse-over status or a kept same-file source-detail range.
 }
 
 @defstruct*[DocumentHighlight ([range Range?])
@@ -625,30 +632,28 @@ Exceptions are noted in individual entries.
                     [pos Pos?])
          (or/c Hover? #f)]{
   Returns hover info at @tt{pos}, or @racket[#f] when check-syntax mouse-over
-  status and same-file source detail are both missing. A docs link alone does not
-  open a hover card.
+  status, Typed Racket type text, and same-file source detail are all missing.
+  A docs link alone does not open a hover card.
 
-  When present, @tt{contents} can include:
+  When present, @tt{contents} follows the fixed @tt{Hover-Card} stack:
   @itemlist[
-    @item{Fenced code summary. For a current same-file trace with local
-          declaration detail, this shows code around the bound declaration.
-          Local uses share that detail. Own-line leading comments may also
-          appear. Usually the summary shows the outermost same-line form
-          (compact binding clause, collapsed one-line header, or complete
-          one-line form). When no form on the identifier line fits, the full
-          nearest enclosing form is shown. Otherwise a Scribble bluebox signature
-          when one exists}
-    @item{A @tt{Check syntax:} line from check-syntax mouse-over status, when
-          present. The text is unchanged.}
-    @item{An online documentation link and, when available, a locally installed
-          docs excerpt (blueboxes preferred for signatures; HTML docs otherwise)}
+    @item{Optional Typed Racket type fence, labeled @tt{Type} or
+          @tt{Type (stale)}}
+    @item{Optional fenced definition (same-file source, else docs signature).
+          Labeled @tt{Source}/@tt{Signature} only when a type precedes it}
+    @item{Optional documentation link and/or excerpt after at most one
+          @tt{---}}
+    @item{Optional check-syntax mouse-over text only when it is the sole
+          content. The text is unchanged and unlabeled}
   ]
 
   Source forms are read from the current buffer through kept trace ranges while an
-  old trace refreshes. The shown form can be useful, but the binding link may be
-  wrong. Code context is limited to 10 lines and 1000 source characters. Leading
-  comments are limited to 10 lines and 200 source characters per line. Mouse-over
-  status and documentation can also appear while an old trace refreshes.
+  old trace refreshes. Retained Typed Racket types remain visible as
+  @tt{Type (stale)}. The shown form or type can be useful, but the binding link
+  or type may be wrong until expansion finishes. Code context is limited to 10
+  lines and 1000 source characters. Leading comments are limited to 10 lines and
+  200 source characters per line. Mouse-over status and documentation can also
+  appear while an old trace refreshes.
 }
 
 @defproc[(doc-completion [doc Doc?]

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -1266,15 +1266,12 @@ END
       (check-true
         (string-contains? (Diagnostic-message typed-diag)
                           "expected: Number"))
-      ;; Expansion also publishes the ordinary Racket exception diagnostic.
-      (define racket-diag
-        (for/first ([diag (in-list diags)]
-                    #:when (string=? (Diagnostic-source diag) "Racket"))
-          diag))
-      (check-not-false racket-diag)
-      (check-true
-        (string-contains? (Diagnostic-message racket-diag)
-                          "Type Checker"))))
+      ;; Exception text wraps the tooltip message; publish only the tooltip.
+      (check-false
+        (for/or ([diag (in-list diags)])
+          (and (string=? (Diagnostic-source diag) "Racket")
+               (string-contains? (Diagnostic-message diag)
+                                 "Type Checker"))))))
 
   (test-case
     "Document hover renders collapsed same-file headers for declarations and uses"

--- a/tests/lib/doc-test.rkt
+++ b/tests/lib/doc-test.rkt
@@ -433,6 +433,43 @@
     (define lexer-state (build-lexer-state text uri))
     (set->list (send (CSResult-trace (check-syntax uri doc-text lexer-state)) get-warn-diags)))
 
+  (define (typed-racket-available?)
+    (with-handlers ([exn:fail? (lambda (_exn) #f)])
+      (dynamic-require 'typed/racket #f)
+      #t))
+
+  (test-case
+    "Expansion logs preserve emission order"
+    (define text
+      (string-append
+        "#lang racket/base\n"
+        "(require (for-syntax racket/base))\n"
+        "(begin-for-syntax\n"
+        "  (log-message (current-logger) 'info 'order-test \"first\" 'first)\n"
+        "  (log-message (current-logger) 'info 'order-test \"second\" 'second))\n"))
+    (define path
+      (string->path "/tmp/expansion-log-order-test.rkt"))
+    (define uri
+      "file:///tmp/expansion-log-order-test.rkt")
+    (define doc-text
+      (new lsp-editor%))
+    (send doc-text insert text 0)
+    (define trace
+      (new build-trace%
+        [src path]
+        [doc-text doc-text]
+        [lexer-state (build-lexer-state text uri)]))
+    (define result
+      (expand-source path
+                     (open-input-string text)
+                     trace))
+    (define order-test-data
+      (for/list ([record (in-list (ExpandResult-logs result))]
+                 #:when (eq? (vector-ref record 3) 'order-test))
+        (vector-ref record 2)))
+    (check-equal? order-test-data
+                  '(first second)))
+
   (test-case
     "Document diagnostics report missing language headers"
     (define text "(define x 1)\n")
@@ -851,35 +888,33 @@ END
     (check-false result))
 
   (test-case
-    "Hover card renders facts without a code summary"
+    "Hover card renders a note without definition"
     (check-equal?
       (render-hover-card
         (Hover-Card #f
-                    (list "Local binding")
-                    (list (Hover-Fact "Check syntax" "bound occurrence of count"))
+                    #f
+                    #f
+                    "bound occurrence of count"
                     #f))
-      "Local binding\n\nCheck syntax: bound occurrence of count"))
+      "bound occurrence of count"))
 
   (test-case
-    "Hover card renders structured sections"
+    "Hover card renders the fixed slot stack"
     (check-equal?
       (render-hover-card
         (Hover-Card
-          (Hover-Code-Summary "(parse-config raw)" "racket")
-          (list "Workspace binding" "config.rkt:12" "phase 0")
-          (list (Hover-Fact "Type" "(-> string? config?)")
-                (Hover-Fact "Contract" "(-> string? config?)"))
+          #f
+          #f
+          (Hover-Definition
+            'source
+            (Hover-Code-Summary "(parse-config raw)" "racket"))
+          #f
           (Hover-Documentation "Parse a configuration value."
                                "https://docs.example.test/parse-config")))
 #<<END
 ```racket
 (parse-config raw)
 ```
-
-Workspace binding | config.rkt:12 | phase 0
-
-Type: (-> string? config?)
-Contract: (-> string? config?)
 
 ---
 
@@ -893,22 +928,185 @@ END
     "Hover card omits empty sections and docs separator"
     (check-equal?
       (render-hover-card
-        (Hover-Card (Hover-Code-Summary "" "racket")
-                    (list "")
-                    '()
+        (Hover-Card #f
+                    #f
+                    #f
+                    #f
                     (Hover-Documentation ""
                                          "https://docs.example.test/parse-config")))
       "[Online docs](https://docs.example.test/parse-config)"))
 
   (test-case
-    "Hover card renders a Rhombus source fence"
+    "Hover card renders a lone Rhombus source fence without a label"
     (check-equal?
       (render-hover-card
-        (Hover-Card (Hover-Code-Summary "fun parse_config(raw): raw" "rhombus")
-                    '()
-                    '()
+        (Hover-Card #f
+                    #f
+                    (Hover-Definition
+                      'source
+                      (Hover-Code-Summary "fun parse_config(raw): raw" "rhombus"))
+                    #f
                     #f))
       "```rhombus\nfun parse_config(raw): raw\n```"))
+
+  (test-case
+    "Hover card labels definition only when a type precedes it"
+    (check-equal?
+      (render-hover-card
+        (Hover-Card
+          (Hover-Code-Summary "Integer" "racket")
+          #t
+          (Hover-Definition
+            'source
+            (Hover-Code-Summary "(define count 1)" "racket"))
+          #f
+          #f))
+      (string-append
+        "**Type (stale)**\n"
+        "```racket\nInteger\n```\n\n"
+        "**Source**\n"
+        "```racket\n(define count 1)\n```")))
+
+  (test-case
+    ;; Check-syntax mouse-over text is mixed; keep it only as a lone note.
+    "build-hover-card omits check-syntax note when a type is present"
+    (define card
+      (build-hover-card #:type-text "Integer"
+                        #:type-stale? #f
+                        #:hover-text " \n Integer \t"
+                        #:link #f
+                        #:signature #f
+                        #:source-summary #f
+                        #:documentation-text #f))
+    (check-equal? (Hover-Card-note card) #f)
+    (check-equal? (render-hover-card card)
+                  (string-append
+                    "**Type**\n"
+                    "```racket\nInteger\n```")))
+
+  (test-case
+    "build-hover-card omits check-syntax note beside richer slots"
+    (define with-type
+      (build-hover-card #:type-text "Integer"
+                        #:type-stale? #f
+                        #:hover-text "bound occurrence"
+                        #:link #f
+                        #:signature #f
+                        #:source-summary #f
+                        #:documentation-text #f))
+    (check-equal? (Hover-Card-note with-type) #f)
+    (check-equal?
+      (render-hover-card with-type)
+      (string-append
+        "**Type**\n"
+        "```racket\nInteger\n```"))
+    (define with-source
+      (build-hover-card #:type-text #f
+                        #:type-stale? #f
+                        #:hover-text "1 bound occurrence"
+                        #:link #f
+                        #:signature #f
+                        #:source-summary (Hover-Code-Summary "(define count 1)" "racket")
+                        #:documentation-text #f))
+    (check-equal? (Hover-Card-note with-source) #f)
+    (check-equal?
+      (render-hover-card with-source)
+      "```racket\n(define count 1)\n```")
+    (define with-docs
+      (build-hover-card #:type-text #f
+                        #:type-stale? #f
+                        #:hover-text "imported from racket"
+                        #:link "https://docs.example.test/map"
+                        #:signature #f
+                        #:source-summary #f
+                        #:documentation-text "Applies proc."))
+    (check-equal? (Hover-Card-note with-docs) #f)
+    (check-equal?
+      (render-hover-card with-docs)
+      (string-append
+        "[Online docs](https://docs.example.test/map)\n\n"
+        "Applies proc.")))
+
+  (test-case
+    "build-hover-card keeps check-syntax text only as sole content"
+    (define card
+      (build-hover-card #:type-text #f
+                        #:type-stale? #f
+                        #:hover-text "bound occurrence"
+                        #:link #f
+                        #:signature #f
+                        #:source-summary #f
+                        #:documentation-text #f))
+    (check-equal? (Hover-Card-note card) "bound occurrence")
+    (check-equal? (render-hover-card card)
+                  "bound occurrence"))
+
+  (test-case
+    "build-hover-card prefers source over signature and labels when typed"
+    (define typed-signature
+      (build-hover-card #:type-text "Integer"
+                        #:type-stale? #f
+                        #:hover-text #f
+                        #:link #f
+                        #:signature "(add1 z) -> number?"
+                        #:source-summary #f
+                        #:documentation-text #f))
+    (check-equal?
+      (render-hover-card typed-signature)
+      (string-append
+        "**Type**\n"
+        "```racket\nInteger\n```\n\n"
+        "**Signature**\n"
+        "```racket\n(add1 z) -> number?\n```"))
+    (define source-over-signature
+      (build-hover-card #:type-text #f
+                        #:type-stale? #f
+                        #:hover-text #f
+                        #:link #f
+                        #:signature "(add1 z) -> number?"
+                        #:source-summary (Hover-Code-Summary "(define count 1)" "racket")
+                        #:documentation-text #f))
+    (check-equal?
+      (Hover-Definition-kind (Hover-Card-definition source-over-signature))
+      'source)
+    (check-equal?
+      (render-hover-card source-over-signature)
+      "```racket\n(define count 1)\n```"))
+
+  (test-case
+    "build-hover-card leaves a lone signature unlabeled"
+    (define card
+      (build-hover-card #:type-text #f
+                        #:type-stale? #f
+                        #:hover-text #f
+                        #:link #f
+                        #:signature "(add1 z) -> number?"
+                        #:source-summary #f
+                        #:documentation-text #f))
+    (check-equal?
+      (render-hover-card card)
+      "```racket\n(add1 z) -> number?\n```"))
+
+  (test-case
+    "build-hover-card marks stale only when a type is present"
+    (check-false
+      (Hover-Card-type-stale?
+        (build-hover-card #:type-text #f
+                          #:type-stale? #t
+                          #:hover-text "bound occurrence"
+                          #:link #f
+                          #:signature #f
+                          #:source-summary #f
+                          #:documentation-text #f)))
+    (check-true
+      (Hover-Card-type-stale?
+        (build-hover-card #:type-text "Integer"
+                          #:type-stale? #t
+                          #:hover-text #f
+                          #:link #f
+                          #:signature #f
+                          #:source-summary #f
+                          #:documentation-text #f))))
 
   (test-case
     "Document hover renders a docs-backed card"
@@ -928,7 +1126,155 @@ END
     (check-true (string-contains? result "```racket"))
     (check-true (string-contains? result "Returns a newly allocated list"))
     (check-true (string-contains? result "[Online docs]"))
-    (check-true (string-contains? result "Check syntax:")))
+    ;; Docs link is present, so check-syntax provenance is omitted.
+    (check-false (string-contains? result "imported from")))
+
+  (test-case
+    "Typed Racket hover renders inferred types, source, ranges, and stale state"
+    (when (typed-racket-available?)
+      (define d
+        (make-doc
+          "file:///tmp/typed-racket-hover-test.rkt"
+          (string-append
+            "#lang typed/racket\n"
+            "(: count Integer)\n"
+            "(define count 1)\n"
+            "(+ count 2)\n")))
+      (check-true (doc-expand! d))
+
+      (define use-hover
+        (doc-hover d (Pos 3 4)))
+      (check-not-false use-hover)
+      (check-equal? (Hover-range use-hover)
+                    (Range (Pos 3 3) (Pos 3 8)))
+      (check-equal?
+        (Hover-contents use-hover)
+        (string-append
+          "**Type**\n"
+          "```racket\nInteger\n```\n\n"
+          "**Source**\n"
+          "```racket\n(define count 1)\n```"))
+
+      ;; Literal and delimiter tooltips remain independently addressable.
+      (define open-paren-hover
+        (doc-hover d (Pos 3 0)))
+      (check-equal? (Hover-range open-paren-hover)
+                    (Range (Pos 3 0) (Pos 3 1)))
+      (check-true
+        (string-contains? (Hover-contents open-paren-hover) "**Type**"))
+      (define literal-hover
+        (doc-hover d (Pos 3 9)))
+      (check-equal? (Hover-range literal-hover)
+                    (Range (Pos 3 9) (Pos 3 10)))
+      (check-true
+        (string-contains? (Hover-contents literal-hover) "**Type**"))
+      (check-equal? (Hover-range (doc-hover d (Pos 3 10)))
+                    (Range (Pos 3 10) (Pos 3 11)))
+
+      (doc-apply-edit! d
+                       (Range (Pos 3 9) (Pos 3 10))
+                       "3")
+      (doc-update-version! d 1)
+      (define stale-hover
+        (doc-hover d (Pos 3 4)))
+      (check-not-false stale-hover)
+      (check-true
+        (string-prefix? (Hover-contents stale-hover)
+                        "**Type (stale)**"))))
+
+  (test-case
+    "Typed Racket hover keeps shifted type ranges while a trace is stale"
+    (when (typed-racket-available?)
+      (define d
+        (make-doc
+          "file:///tmp/typed-racket-stale-shift-test.rkt"
+          (string-append
+            "#lang typed/racket\n"
+            "(: count Integer)\n"
+            "(define count 1)\n"
+            "(+ count 2)\n")))
+      (check-true (doc-expand! d))
+      (doc-apply-edit! d (Range (Pos 3 0) (Pos 3 0)) "    ")
+      (doc-update-version! d 1)
+      (define shifted-hover
+        (doc-hover d (Pos 3 8)))
+      (check-not-false shifted-hover)
+      (check-equal? (Hover-range shifted-hover)
+                    (Range (Pos 3 7) (Pos 3 12)))
+      (check-true
+        (string-prefix? (Hover-contents shifted-hover)
+                        "**Type (stale)**"))
+      (check-true
+        (string-contains? (Hover-contents shifted-hover)
+                          "(define count 1)"))))
+
+  (test-case
+    "Typed Racket import hover shows type before signature"
+    (when (typed-racket-available?)
+      (define d
+        (make-doc
+          "file:///tmp/typed-racket-import-hover-test.rkt"
+          "#lang typed/racket\n(add1 1)\n"))
+      (check-true (doc-expand! d))
+      (define hover
+        (doc-hover d (Pos 1 1)))
+      (check-not-false hover)
+      (define contents
+        (Hover-contents hover))
+      (define type-pos
+        (car (regexp-match-positions #rx"\\*\\*Type\\*\\*" contents)))
+      (define signature-pos
+        (car (regexp-match-positions #rx"\\*\\*Signature\\*\\*" contents)))
+      (check-not-false type-pos)
+      (check-not-false signature-pos)
+      (check-true (< (car type-pos) (car signature-pos)))
+      (check-true (string-contains? contents "```racket"))
+      (check-false (string-contains? contents "**Source**"))
+      (check-false (string-contains? contents "imported from"))))
+
+  (test-case
+    "Untyped documents do not gain Typed Racket type cards"
+    (define d
+      (make-doc
+        "file:///tmp/untyped-no-type-card-test.rkt"
+        "#lang racket\n(define count 1)\n(+ count 2)\n"))
+    (check-true (doc-expand! d))
+    (define hover
+      (doc-hover d (Pos 2 4)))
+    (check-not-false hover)
+    (check-false
+      (string-contains? (Hover-contents hover) "**Type**"))
+    (check-true
+      (string-contains? (Hover-contents hover) "```racket")))
+
+  (test-case
+    ;; Type-error tooltips must arrive via typed-racket%, not diag%.
+    "Typed Racket tooltip decoder routes type errors into diagnostics"
+    (when (typed-racket-available?)
+      (define diags
+        (check-syntax-diagnostics
+          "file:///tmp/typed-racket-error-test.rkt"
+          "#lang typed/racket\n(+ 1 \"x\")\n"))
+      (define typed-diag
+        (for/first ([diag (in-list diags)]
+                    #:when (string=? (Diagnostic-source diag)
+                                     "Typed Racket"))
+          diag))
+      (check-not-false typed-diag)
+      (check-equal? (Diagnostic-range typed-diag)
+                    (Range (Pos 1 5) (Pos 1 8)))
+      (check-true
+        (string-contains? (Diagnostic-message typed-diag)
+                          "expected: Number"))
+      ;; Expansion also publishes the ordinary Racket exception diagnostic.
+      (define racket-diag
+        (for/first ([diag (in-list diags)]
+                    #:when (string=? (Diagnostic-source diag) "Racket"))
+          diag))
+      (check-not-false racket-diag)
+      (check-true
+        (string-contains? (Diagnostic-message racket-diag)
+                          "Type Checker"))))
 
   (test-case
     "Document hover renders collapsed same-file headers for declarations and uses"
@@ -956,14 +1302,14 @@ END
     ;; Headers and macro binders get outer context. Binder names are not matched.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 3 9)))
-      "```racket\n(define (parse-config raw) raw)\n```\n\nCheck syntax: 1 bound occurrence")
+      "```racket\n(define (parse-config raw) raw)\n```")
     ;; A function use shows the declaration, not the call site.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 5 2)))
       "```racket\n(define (parse-config raw) raw)\n```")
     (check-equal?
       (Hover-contents (doc-hover d (Pos 4 12)))
-      "```racket\n(for/list ([element (list 1)]) element)\n```\n\nCheck syntax: 1 bound occurrence"))
+      "```racket\n(for/list ([element (list 1)]) element)\n```"))
 
   (test-case
     "Document hover balances compact clauses with collapsed headers"
@@ -976,19 +1322,19 @@ END
     ;; A later binding gets its own clause, not a prefix with earlier bindings.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 2 7)))
-      "```racket\n[limit 10]\n```\n\nCheck syntax: 1 bound occurrence")
+      "```racket\n[limit 10]\n```")
     ;; No same-line header. Show the full nearest form.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 5 9)))
-      "```racket\n(fib\n         n)\n```\n\nCheck syntax: 1 bound occurrence")
+      "```racket\n(fib\n         n)\n```")
     ;; A complete one-line declaration stays complete.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 7 8)))
-      "```racket\n(define answer (string-length \"input\"))\n```\n\nCheck syntax: no bound occurrences")
+      "```racket\n(define answer (string-length \"input\"))\n```")
     ;; A same-line header keeps its comment and marks the omitted body.
     (check-equal?
       (Hover-contents (doc-hover d (Pos 8 9)))
-      "```racket\n(define (parse raw) ; accepts overrides\n  ...\n```\n\nCheck syntax: no bound occurrences"))
+      "```racket\n(define (parse raw) ; accepts overrides\n  ...\n```"))
 
   (test-case
     "Document hover renders leading comments for declarations and local bindings"
@@ -999,10 +1345,10 @@ END
     (check-true (doc-expand! d))
     (check-equal?
       (Hover-contents (doc-hover d (Pos 3 9)))
-      "```racket\n;; Produces the next Fibonacci value.\n;; Kept separate from callers for reuse.\n(define (fib value)\n  ...\n```\n\nCheck syntax: no bound occurrences")
+      "```racket\n;; Produces the next Fibonacci value.\n;; Kept separate from callers for reuse.\n(define (fib value)\n  ...\n```")
     (check-equal?
       (Hover-contents (doc-hover d (Pos 7 7)))
-      "```racket\n;; Counts visits in this branch.\n[count 1]\n```\n\nCheck syntax: 1 bound occurrence"))
+      "```racket\n;; Counts visits in this branch.\n[count 1]\n```"))
 
   (test-case
     "Document hover leaves separated and trailing comments unattached"
@@ -1052,7 +1398,7 @@ END
     (check-true (doc-expand! d))
     (check-equal?
       (Hover-contents (doc-hover d (Pos 4 14)))
-      "```racket\n[ln (in-naturals)]\n```\n\nCheck syntax: 3 bound occurrences"))
+      "```racket\n[ln (in-naturals)]\n```"))
 
   (test-case
     "Document hover shows the complete nearest struct form"
@@ -1063,7 +1409,7 @@ END
     (check-true (doc-expand! d))
     (check-equal?
       (Hover-contents (doc-hover d (Pos 1 8)))
-      "```racket\n(struct RopeNode\n  (left\n   right\n   chars\n   newlines\n   height)\n  #:transparent)\n```\n\nCheck syntax: no bound occurrences"))
+      "```racket\n(struct RopeNode\n  (left\n   right\n   chars\n   newlines\n   height)\n  #:transparent)\n```"))
 
   (test-case
     "Document hover keeps imported symbols out of same-file source detail"
@@ -1073,8 +1419,11 @@ END
     (check-true (doc-expand! d))
     (define imported-hover (doc-hover d (Pos 1 1)))
     (check-not-false imported-hover)
-    (check-true (string-contains? (Hover-contents imported-hover)
-                                  "Check syntax:")))
+    (define contents (Hover-contents imported-hover))
+    (check-false (string-contains? contents "**Source**"))
+    (check-true (string-contains? contents "[Online docs]"))
+    ;; Docs link fills the card, so check-syntax provenance is omitted.
+    (check-false (string-contains? contents "imported from")))
 
   (test-case
     "Document hover keeps cross-file workspace bindings out of source detail"
@@ -1095,7 +1444,7 @@ END
         (define imported-hover (doc-hover d (Pos 2 1)))
         (check-not-false imported-hover)
         (check-true (string-contains? (Hover-contents imported-hover)
-                                      "Check syntax:")))
+                                      "imported from")))
       (lambda ()
         (delete-directory/files temp-dir))))
 
@@ -1151,8 +1500,9 @@ END
     (define d (make-doc "file:///tmp/hover-detail-truncate.rkt" text))
     (check-true (doc-expand! d))
     (define result (Hover-contents (doc-hover d (Pos 1 7))))
+    (check-true (string-prefix? result "```racket\n"))
     (define match
-      (regexp-match #px"```racket\n((.|\n)*)\n```" result))
+      (regexp-match #px"```racket\n((?:.|\n)*)\n```" result))
     (check-not-false match)
     (define code (cadr match))
     (check-true (<= (string-length code) 1004))
@@ -1174,17 +1524,17 @@ END
       ;; inherit the Rhombus root aggregate range.
       (check-equal?
         (Hover-contents (doc-hover d (Pos 1 4)))
-        "```rhombus\ndef value = 1\n```\n\nCheck syntax: no bound occurrences")
+        "```rhombus\ndef value = 1\n```")
       (check-equal?
         (Hover-contents (doc-hover d (Pos 2 4)))
-        "```rhombus\nfun parse_value(raw): raw\n```\n\nCheck syntax: no bound occurrences")
+        "```rhombus\nfun parse_value(raw): raw\n```")
       (define comment-d
         (make-doc "file:///tmp/hover-detail-comments.rhm"
                   "#lang rhombus\n// Converts the value.\nfun documented(value): value\n"))
       (check-true (doc-expand! comment-d))
       (check-equal?
         (Hover-contents (doc-hover comment-d (Pos 2 4)))
-        "```rhombus\n// Converts the value.\nfun documented(value): value\n```\n\nCheck syntax: no bound occurrences")
+        "```rhombus\n// Converts the value.\nfun documented(value): value\n```")
       ;; A bound use must find detail through `declaration-at`, not only through
       ;; definition targets.
       (define use-d

--- a/tests/lib/typed-racket-decoder-test.rkt
+++ b/tests/lib/typed-racket-decoder-test.rkt
@@ -1,0 +1,226 @@
+#lang racket/base
+
+;; Classifier and direct-decoder coverage for Typed Racket online-check-syntax
+;; logs. These live under tests/ so CI (`raco test -c racket-langserver/tests`)
+;; runs them. Chosen over full-document expansion for message matching,
+;; property-tree decoding, source filtering, and records that must be ignored
+;; without raising.
+
+(require rackunit
+         "../../doclib/editor.rkt"
+         "../../doclib/service/typed-racket/decoder.rkt"
+         "../../doclib/service/typed-racket/service.rkt"
+         racket/class
+         racket/set
+         racket/string)
+
+(define source "/tmp/typed-racket-tooltip-test.rkt")
+(define foreign-source "/tmp/other-file.rkt")
+
+(define (online-log message data)
+  (vector 'info message data 'online-check-syntax))
+
+(define (inferred-log data)
+  (online-log (string-append "online-check-syntax: "
+                             typed-racket-inferred-type-message)
+              data))
+
+(define (type-error-log data)
+  (online-log (string-append "online-check-syntax: "
+                             typed-racket-type-error-message)
+              data))
+
+(define (located-at src pos span datum)
+  (datum->syntax #f
+                 datum
+                 (list src 1 0 (add1 pos) span)))
+
+(define (tooltip-syntax #:source [src source]
+                        #:left [left 0]
+                        #:right [right 1]
+                        #:text [text "Integer"]
+                        #:thunk? [thunk? #f])
+  (define located
+    (located-at src left (- right left) 'value))
+  (syntax-property
+    (datum->syntax #f
+                   '(void)
+                   (list src 1 0 1 5))
+    'mouse-over-tooltips
+    (vector located
+            left
+            right
+            (if thunk?
+                (lambda () text)
+                text))))
+
+;; Two endpoint tooltips with the same message, as Typed Racket emits for some
+;; compound type-error spans.
+(define (pair-tooltip-syntax left-start left-end right-start right-end text
+                             #:source [src source])
+  (define left-located
+    (located-at src left-start (- left-end left-start) 'left))
+  (define right-located
+    (located-at src right-start (- right-end right-start) 'right))
+  (syntax-property
+    (datum->syntax #f
+                   '(void)
+                   (list src 1 0 1 5))
+    'mouse-over-tooltips
+    (cons (vector left-located left-start left-end text)
+          (vector right-located right-start right-end text))))
+
+(define (annotate logs)
+  (typed-racket-log-annotations logs source))
+
+(module+ test
+  (test-case
+    "Inferred-type logs force thunks, skip empty text, and ignore unknown records"
+    (define empty-tooltip-syntax
+      (syntax-property
+        (located-at source 1 3 'value)
+        'mouse-over-tooltips
+        (vector (located-at source 1 3 'value) 1 4 "")))
+    (check-equal?
+      (annotate
+        (list (inferred-log
+                (list (tooltip-syntax #:left 0 #:right 1 #:thunk? #t)
+                      (tooltip-syntax #:left 4 #:right 5)
+                      empty-tooltip-syntax))
+              ;; Unknown records on the same topic are ignored.
+              (online-log "online-check-syntax: unfamiliar tooltip record"
+                          (list (tooltip-syntax)))
+              ;; Recognized records with bad payloads are ignored without raising.
+              (type-error-log (list 'not-syntax))))
+      (list (Inferred-Type source 0 1 "Integer")
+            (Inferred-Type source 4 5 "Integer"))))
+
+  (test-case
+    "Type-error logs merge matching endpoint tooltips into one range"
+    (check-equal?
+      (annotate
+        (list (type-error-log
+                (list (pair-tooltip-syntax 0 1 4 5 "type mismatch")))))
+      (list (Type-Error source 0 5 "type mismatch"))))
+
+  (test-case
+    "Type-error logs keep distinct messages as separate diagnostics"
+    (define left
+      (tooltip-syntax #:left 0 #:right 1 #:text "expected Number"))
+    (define right
+      (tooltip-syntax #:left 4 #:right 5 #:text "given String"))
+    (check-equal?
+      (annotate (list (type-error-log (list left right))))
+      (list (Type-Error source 0 1 "expected Number")
+            (Type-Error source 4 5 "given String"))))
+
+  (test-case
+    "Foreign-source tooltip syntax is filtered before forcing its text"
+    (define foreign-tooltip-forced? #f)
+    (check-equal?
+      (annotate
+        (list (inferred-log
+                (list (tooltip-syntax #:source foreign-source
+                                      #:left 0
+                                      #:right 3
+                                      #:text
+                                      (lambda ()
+                                        (set! foreign-tooltip-forced? #t)
+                                        "Ignored"))))))
+      '())
+    (check-false foreign-tooltip-forced?))
+
+  (test-case
+    "Property pair trees ignore malformed leaves and preserve valid order"
+    (define first-tooltip
+      (vector (located-at source 0 1 'first) 0 1 "First"))
+    (define second-tooltip
+      (vector (located-at source 2 1 'second) 2 3 "Second"))
+    (define carrier
+      (syntax-property
+        (located-at source 0 3 'carrier)
+        'mouse-over-tooltips
+        (cons (cons first-tooltip 'ignored-leaf)
+              second-tooltip)))
+    (check-equal?
+      (annotate (list (inferred-log (list carrier))))
+      (list (Inferred-Type source 0 1 "First")
+            (Inferred-Type source 2 3 "Second"))))
+
+  (test-case
+    "A failing provider thunk reports to stderr and keeps later records"
+    (define failing-tooltip
+      (tooltip-syntax #:text
+                      (lambda ()
+                        (error 'tooltip-text "provider failure"))))
+    (define err (open-output-string))
+    (define result
+      (parameterize ([current-error-port err])
+        (annotate
+          (list (inferred-log (list failing-tooltip))
+                (inferred-log
+                  (list (tooltip-syntax #:left 4
+                                        #:right 5
+                                        #:text "Survived")))))))
+    (check-equal? result
+                  (list (Inferred-Type source 4 5 "Survived")))
+    (define err-text (get-output-string err))
+    (check-true (string-contains? err-text "inferred-type"))
+    (check-true (string-contains? err-text "provider failure")))
+
+  (test-case
+    "The service rejects tooltip ranges beyond the document snapshot"
+    (define doc-text
+      (new lsp-editor%))
+    (send doc-text insert "abc" 0)
+    (define service
+      (new typed-racket%
+        [src source]
+        [doc-text doc-text]))
+    (send service
+          walk-log
+          (list
+            (inferred-log
+              (list (tooltip-syntax #:left 0
+                                    #:right 1
+                                    #:text "Valid")
+                    (tooltip-syntax #:left 2
+                                    #:right 4
+                                    #:text "Outside")))
+            (type-error-log
+              (list (tooltip-syntax #:left 2
+                                    #:right 4
+                                    #:text "Outside error")))))
+    (define-values (start end text)
+      (send service inferred-type-at 0))
+    (check-equal? (list start end text)
+                  (list 0 1 "Valid"))
+    (define-values (_outside-start _outside-end outside-text)
+      (send service inferred-type-at 2))
+    (check-false outside-text)
+    (check-equal? (set-count (send service get-diagnostics)) 0))
+
+  (test-case
+    "Non online-check-syntax topics and malformed vectors are ignored"
+    (check-equal?
+      (annotate
+        (list (vector 'info
+                      (string-append "online-check-syntax: "
+                                     typed-racket-inferred-type-message)
+                      (list (tooltip-syntax))
+                      'something-else)
+              (vector 'info "short")
+              (inferred-log #f)
+              (inferred-log '())
+              (inferred-log (list (tooltip-syntax)))))
+      (list (Inferred-Type source 0 1 "Integer"))))
+
+  (test-case
+    ;; Invariant: suffix match must classify even when Typed Racket omits the
+    ;; "online-check-syntax: " topic prefix.
+    "Message matching accepts the Typed Racket suffix without a topic prefix"
+    (check-equal?
+      (annotate
+        (list (online-log typed-racket-type-error-message
+                          (list (tooltip-syntax #:text "boom")))))
+      (list (Type-Error source 0 1 "boom")))))


### PR DESCRIPTION
This copies Emacs [racket-mode's approach](https://github.com/greghendershott/racket-mode/blob/master/racket/online-check-syntax.rkt) (not code). It extracts typed racket payload data from logs that produced during expansion, then parse it. The payload data is a list of syntaxes, they have `'mouse-over-tooltips` syntax properties attached. The syntax property itself is a tree of pairs, its leaves are vectors that really contain type info or type error of source code (range start,  range end, type text) we need.

All typed racket logic now move to `typed-racket%` service including type info and type error diagnostics. The `diag%` service can also returns same typed racket's diagnostics, but its messages are less pretty than messages from `typed-racket%`. Thus there is deduplicate logic in `get-warn-diags` method.

I also redesigned hover layout again. Because it can show 2 code block (type and source code summary) at the same time.

**Screenshot**

<img width="978" height="320" alt="Screenshot From 2026-07-27 20-24-16" src="https://github.com/user-attachments/assets/fbc86cb2-c9b0-45e0-b932-a569ee9ccf29" />

You can also hover on any open or close parentheses for that expression's type:

<img width="690" height="208" alt="Screenshot From 2026-07-27 20-24-28" src="https://github.com/user-attachments/assets/7b6a98b0-49d8-483a-af14-4a163a538b99" />

And type error:

<img width="828" height="474" alt="Screenshot From 2026-07-27 20-25-06" src="https://github.com/user-attachments/assets/cfce75b1-c6d8-4058-ad0b-5fef5a018d84" />
